### PR TITLE
chore: disable body-max-line-length commitlint rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 export default {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0],
+  },
 };


### PR DESCRIPTION
Dependabot PRs generate long body lines that fail the commitlint check. Disabling this rule unblocks all 14 pending dependabot PRs.