### PR TITLE
fix: skip lifecycle scripts in prod Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod --ignore-scripts
 
 FROM base AS runtime
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
The `prepare` lifecycle script runs `husky`, which is a devDependency and not available during `--prod` installs. Adds `--ignore-scripts` to the Dockerfile's pnpm install step.

This fixes the container scan CI job that's been failing after every merge to main.