### PR TITLE
feat(handler): add handler chain for sequential execution

### DIFF
--- a/src/handler/chain.js
+++ b/src/handler/chain.js
@@ -1,0 +1,44 @@
+// Handler chain: registers multiple handlers per request type and executes
+// them sequentially until one handles the request or an error occurs.
+//
+// Follows the chain of responsibility pattern (like Express middleware).
+// Each handler either handles (exit 0), passes (exit 1), or errors (exit 2).
+
+export class HandlerChain {
+  constructor({ timeout, executor }) {
+    this.timeout = timeout;
+    this.executor = executor;
+    this.handlers = new Map();
+  }
+
+  // Register a handler command for a request type. Handlers are called
+  // in registration order when a request of that type comes in.
+  register(requestType, command) {
+    if (!this.handlers.has(requestType)) {
+      this.handlers.set(requestType, []);
+    }
+    this.handlers.get(requestType).push(command);
+  }
+
+  // Execute the handler chain for a request type. Returns the result from
+  // the first handler that handles or errors. Returns { status: "no-handler" }
+  // if no handlers are registered or all handlers pass.
+  async execute(requestType, request) {
+    const commands = this.handlers.get(requestType);
+    if (!commands || commands.length === 0) {
+      return { status: "no-handler", stdout: "", stderr: "" };
+    }
+
+    for (const command of commands) {
+      const result = await this.executor(command, request, {
+        timeout: this.timeout,
+      });
+
+      if (result.status === "handled" || result.status === "error") {
+        return result;
+      }
+    }
+
+    return { status: "no-handler", stdout: "", stderr: "" };
+  }
+}

--- a/test/unit/handler/chain.test.js
+++ b/test/unit/handler/chain.test.js
@@ -1,0 +1,162 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { HandlerChain } from "../../../src/handler/chain.js";
+
+// Stub executor that returns predefined results per command
+function stubExecutor(results) {
+  const calls = [];
+  const executor = async (command, request, options) => {
+    calls.push({ command, request, options });
+    return results[command];
+  };
+  return { executor, calls };
+}
+
+const baseRequest = {
+  path: "/latest/meta-data/iam/security-credentials/my-role",
+  containerId: "abc123",
+  containerName: "my-app",
+  containerLabels: "{}",
+};
+
+test("HandlerChain: returns no-handler when no handlers registered", async () => {
+  const { executor } = stubExecutor({});
+  const chain = new HandlerChain({ timeout: 5000, executor });
+
+  const result = await chain.execute("credentials", baseRequest);
+  assert.equal(result.status, "no-handler");
+});
+
+test("HandlerChain: returns no-handler for unregistered request type", async () => {
+  const { executor } = stubExecutor({
+    "/usr/bin/handler-a": { status: "handled", stdout: "ok", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/handler-a");
+
+  const result = await chain.execute("region", baseRequest);
+  assert.equal(result.status, "no-handler");
+});
+
+test("HandlerChain: single handler that handles returns its result", async () => {
+  const { executor } = stubExecutor({
+    "/usr/bin/creds": { status: "handled", stdout: '{"key":"val"}', stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/creds");
+
+  const result = await chain.execute("credentials", baseRequest);
+  assert.equal(result.status, "handled");
+  assert.equal(result.stdout, '{"key":"val"}');
+});
+
+test("HandlerChain: first handler passes, second handles", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/skip": { status: "pass", stdout: "", stderr: "", timedOut: false },
+    "/usr/bin/handle": { status: "handled", stdout: "response", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/skip");
+  chain.register("credentials", "/usr/bin/handle");
+
+  const result = await chain.execute("credentials", baseRequest);
+  assert.equal(result.status, "handled");
+  assert.equal(result.stdout, "response");
+  assert.equal(calls.length, 2);
+});
+
+test("HandlerChain: first handler handles, second is not called", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/first": { status: "handled", stdout: "first", stderr: "", timedOut: false },
+    "/usr/bin/second": { status: "handled", stdout: "second", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/first");
+  chain.register("credentials", "/usr/bin/second");
+
+  const result = await chain.execute("credentials", baseRequest);
+  assert.equal(result.status, "handled");
+  assert.equal(result.stdout, "first");
+  assert.equal(calls.length, 1);
+});
+
+test("HandlerChain: error stops the chain", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/broken": { status: "error", stdout: "", stderr: "boom", timedOut: false },
+    "/usr/bin/good": { status: "handled", stdout: "ok", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/broken");
+  chain.register("credentials", "/usr/bin/good");
+
+  const result = await chain.execute("credentials", baseRequest);
+  assert.equal(result.status, "error");
+  assert.equal(result.stderr, "boom");
+  assert.equal(calls.length, 1);
+});
+
+test("HandlerChain: all handlers pass returns no-handler", async () => {
+  const { executor } = stubExecutor({
+    "/usr/bin/a": { status: "pass", stdout: "", stderr: "", timedOut: false },
+    "/usr/bin/b": { status: "pass", stdout: "", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/a");
+  chain.register("credentials", "/usr/bin/b");
+
+  const result = await chain.execute("credentials", baseRequest);
+  assert.equal(result.status, "no-handler");
+});
+
+test("HandlerChain: passes timeout to executor", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/cmd": { status: "handled", stdout: "", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 3000, executor });
+  chain.register("credentials", "/usr/bin/cmd");
+
+  await chain.execute("credentials", baseRequest);
+  assert.equal(calls[0].options.timeout, 3000);
+});
+
+test("HandlerChain: passes request to executor", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/cmd": { status: "handled", stdout: "", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/cmd");
+
+  await chain.execute("credentials", baseRequest);
+  assert.deepEqual(calls[0].request, baseRequest);
+});
+
+test("HandlerChain: multiple request types are independent", async () => {
+  const { executor } = stubExecutor({
+    "/usr/bin/creds": { status: "handled", stdout: "creds", stderr: "", timedOut: false },
+    "/usr/bin/region": { status: "handled", stdout: "us-east-1", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/creds");
+  chain.register("region", "/usr/bin/region");
+
+  const credsResult = await chain.execute("credentials", baseRequest);
+  assert.equal(credsResult.stdout, "creds");
+
+  const regionResult = await chain.execute("region", baseRequest);
+  assert.equal(regionResult.stdout, "us-east-1");
+});
+
+test("HandlerChain: registration order is preserved", async () => {
+  const order = [];
+  const executor = async (command) => {
+    order.push(command);
+    return { status: "pass", stdout: "", stderr: "", timedOut: false };
+  };
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/first");
+  chain.register("credentials", "/usr/bin/second");
+  chain.register("credentials", "/usr/bin/third");
+
+  await chain.execute("credentials", baseRequest);
+  assert.deepEqual(order, ["/usr/bin/first", "/usr/bin/second", "/usr/bin/third"]);
+});


### PR DESCRIPTION
## Summary
- Adds `HandlerChain` class implementing chain of responsibility pattern for handler routing
- Multiple handlers register per request type, executed sequentially in registration order
- First handler to handle (exit 0) or error (exit 2) stops the chain; pass (exit 1) continues
- Executor injected via constructor for testability
- 11 unit tests covering all routing scenarios

Closes #16

## Test plan
- [x] All 11 unit tests passing
- [x] ESLint clean
- [ ] CI passes