### PR TITLE
feat(config): add handler configuration schema

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,75 @@
+# imds-server configuration
+#
+# Copy this file to ~/.imds-server.yml and adjust as needed.
+# The server loads ~/.imds-server.yml automatically. Override with --config.
+
+# Server listen address. Use 0.0.0.0 to listen on all interfaces.
+# host: 127.0.0.1
+# port: 80
+
+# Or listen on a unix domain socket instead of TCP (mutually exclusive with host/port).
+# socket: /tmp/imds.sock
+
+# IMDSv1, IMDSv2, or auto (accepts both). IMDSv2 requires a token via PUT /latest/api/token.
+# imdsVersion: auto
+
+# Token time-to-live in seconds (1-21600). Only relevant for IMDSv2.
+# tokenTtl: 21600
+
+# Log level: debug, info, warn, error
+# logLevel: info
+
+# Default timeout for handler commands in milliseconds (100-30000).
+# Individual handlers can override this with their own timeout value.
+# handlerTimeout: 5000
+
+# Handlers
+#
+# Each handler is an external command that the server calls to generate
+# responses for IMDS requests. Handlers are called in order -- the first
+# one that handles a request wins.
+#
+# Fields:
+#   command  - path to the executable (script, binary, whatever)
+#   types    - list of IMDS request types this handler responds to
+#   timeout  - optional per-handler timeout in ms (overrides handlerTimeout)
+#
+# Available request types:
+#   credentials       - IAM security credentials (/latest/meta-data/iam/security-credentials/*)
+#   region            - placement region
+#   availability-zone - placement availability zone
+#   instance-id       - instance identity
+#   hostname          - hostname or local-hostname
+#   local-ipv4        - local IPv4 address
+#   public-ipv4       - public IPv4 address
+#   instance-identity - instance identity document (/latest/dynamic/instance-identity/document)
+#
+# How handlers work:
+#
+#   The server calls your command with these arguments:
+#
+#     your-handler \
+#       --path /latest/meta-data/iam/security-credentials/my-role \
+#       --container-id abc123def456 \
+#       --container-name my-app \
+#       --container-labels '{"imds.role":"arn:aws:iam::123456:role/dev"}'
+#
+#   Your handler writes its response to stdout and exits with one of:
+#
+#     exit 0  - handled. stdout becomes the response body.
+#     exit 1  - pass. not my problem, try the next handler.
+#     exit 2  - error. stop the chain, server returns 500.
+#
+# Example:
+#
+# handlers:
+#   - command: /opt/handlers/aws-creds
+#     types:
+#       - credentials
+#     timeout: 10000
+#   - command: /opt/handlers/fallback
+#     types:
+#       - credentials
+#       - region
+#       - instance-id
+handlers: []

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -7,9 +7,9 @@ const defaults = Object.freeze({
   socket: null,
   tokenTtl: 21600,
   imdsVersion: "auto",
-  configFile: null,
-  handlerCommand: null,
-  handlerCommandTimeout: 5000,
+  configFile: "~/.imds-server.yml",
+  handlers: [],
+  handlerTimeout: 5000,
   logLevel: "info",
 });
 

--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -2,6 +2,7 @@
 // CLI args > env vars > config file > defaults.
 
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { parseArgs } from "node:util";
 import { parse as parseYaml } from "yaml";
 import defaults from "./defaults.js";
@@ -10,6 +11,7 @@ import {
   extractCliValues,
   extractEnvValues,
   validate,
+  validateHandlers,
   validateMutualExclusion,
   schema,
 } from "./schema.js";
@@ -50,6 +52,10 @@ export function loadConfigFile(filePath) {
 
   const result = {};
   for (const [key, value] of Object.entries(parsed)) {
+    if (key === "handlers") {
+      result.handlers = value;
+      continue;
+    }
     if (!(key in schema)) continue;
     result[key] = schema[key].coerce(value);
   }
@@ -64,8 +70,24 @@ export function loadConfig(cliValues = {}, env = process.env) {
   const envConfig = extractEnvValues(env);
 
   // Determine config file path: CLI > env > default
-  const configFilePath = cliConfig.configFile ?? envConfig.configFile ?? defaults.configFile;
-  const fileConfig = configFilePath ? loadConfigFile(configFilePath) : {};
+  const explicitConfigFile = cliConfig.configFile ?? envConfig.configFile;
+  const rawConfigPath = explicitConfigFile ?? defaults.configFile;
+  const configFilePath = rawConfigPath?.startsWith("~/")
+    ? homedir() + rawConfigPath.slice(1)
+    : rawConfigPath;
+
+  let fileConfig = {};
+  if (configFilePath) {
+    try {
+      fileConfig = loadConfigFile(configFilePath);
+    } catch (err) {
+      // Only swallow missing file errors for the default path.
+      // If the user explicitly set a config file, let it throw.
+      if (explicitConfigFile || !err.message.includes("not found")) {
+        throw err;
+      }
+    }
+  }
 
   const explicitKeys = new Set([
     ...Object.keys(cliConfig),
@@ -73,15 +95,20 @@ export function loadConfig(cliValues = {}, env = process.env) {
     ...Object.keys(fileConfig),
   ]);
 
+  // Handlers come from config file only (not CLI/env).
+  const handlers = fileConfig.handlers ?? defaults.handlers;
+
   const config = {
     ...defaults,
     ...fileConfig,
     ...envConfig,
     ...cliConfig,
+    handlers,
   };
 
   validateMutualExclusion(explicitKeys);
   validate(config);
+  validateHandlers(config.handlers);
 
   return Object.freeze(config);
 }

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -66,25 +66,15 @@ const schema = {
         ? null
         : "configFile must be a non-empty string or null",
   },
-  handlerCommand: {
-    type: "string",
-    cliFlag: "handler-command",
-    envVar: "IMDS_HANDLER_COMMAND",
-    coerce: String,
-    validate: (v) =>
-      v === null || (typeof v === "string" && v.length > 0)
-        ? null
-        : "handlerCommand must be a non-empty string or null",
-  },
-  handlerCommandTimeout: {
+  handlerTimeout: {
     type: "number",
-    cliFlag: "handler-command-timeout",
-    envVar: "IMDS_HANDLER_COMMAND_TIMEOUT",
+    cliFlag: "handler-timeout",
+    envVar: "IMDS_HANDLER_TIMEOUT",
     coerce: Number,
     validate: (v) =>
       Number.isInteger(v) && v >= 100 && v <= 30000
         ? null
-        : "handlerCommandTimeout must be an integer between 100 and 30000 (ms)",
+        : "handlerTimeout must be an integer between 100 and 30000 (ms)",
   },
   logLevel: {
     type: "string",
@@ -170,6 +160,42 @@ export function validateMutualExclusion(explicitKeys) {
 
   if (hasSocket && hasHostOrPort) {
     throw new Error("Config validation error: --socket and --host/--port are mutually exclusive");
+  }
+}
+
+// Validate the handlers array from the config file.
+// Each entry must have a non-empty command string and a non-empty types array.
+// Timeout is optional but must be a valid integer in range if present.
+export function validateHandlers(handlers) {
+  if (!Array.isArray(handlers)) {
+    throw new Error("Config validation error: handlers must be an array");
+  }
+
+  for (let i = 0; i < handlers.length; i++) {
+    const h = handlers[i];
+    const prefix = `handlers[${i}]`;
+
+    if (typeof h.command !== "string" || h.command.length === 0) {
+      throw new Error(`Config validation error: ${prefix}.command must be a non-empty string`);
+    }
+
+    if (
+      !Array.isArray(h.types) ||
+      h.types.length === 0 ||
+      !h.types.every((t) => typeof t === "string")
+    ) {
+      throw new Error(
+        `Config validation error: ${prefix}.types must be a non-empty array of strings`,
+      );
+    }
+
+    if (h.timeout !== undefined) {
+      if (!Number.isInteger(h.timeout) || h.timeout < 100 || h.timeout > 30000) {
+        throw new Error(
+          `Config validation error: ${prefix}.timeout must be an integer between 100 and 30000 (ms)`,
+        );
+      }
+    }
   }
 }
 

--- a/test/integration/config-layers.test.js
+++ b/test/integration/config-layers.test.js
@@ -94,11 +94,7 @@ describe("config layer priority (integration)", () => {
       assert.equal(config.logLevel, "warn", "env wins over file");
       assert.equal(config.host, "10.0.0.1", "file wins over default");
       assert.equal(config.tokenTtl, 600, "file wins over default for tokenTtl");
-      assert.equal(
-        config.handlerCommandTimeout,
-        defaults.handlerCommandTimeout,
-        "default used when no override",
-      );
+      assert.equal(config.handlerTimeout, defaults.handlerTimeout, "default used when no override");
     } finally {
       teardown();
     }

--- a/test/unit/config/defaults.test.js
+++ b/test/unit/config/defaults.test.js
@@ -21,8 +21,8 @@ describe("config/defaults", () => {
       "tokenTtl",
       "imdsVersion",
       "configFile",
-      "handlerCommand",
-      "handlerCommandTimeout",
+      "handlers",
+      "handlerTimeout",
       "logLevel",
     ];
     assert.deepStrictEqual(Object.keys(defaults).sort(), expectedKeys.sort());
@@ -34,9 +34,9 @@ describe("config/defaults", () => {
     assert.equal(defaults.socket, null);
     assert.equal(defaults.tokenTtl, 21600);
     assert.equal(defaults.imdsVersion, "auto");
-    assert.equal(defaults.configFile, null);
-    assert.equal(defaults.handlerCommand, null);
-    assert.equal(defaults.handlerCommandTimeout, 5000);
+    assert.equal(defaults.configFile, "~/.imds-server.yml");
+    assert.deepEqual(defaults.handlers, []);
+    assert.equal(defaults.handlerTimeout, 5000);
     assert.equal(defaults.logLevel, "info");
   });
 });

--- a/test/unit/config/handlers.test.js
+++ b/test/unit/config/handlers.test.js
@@ -1,0 +1,120 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { validateHandlers } from "../../../src/config/schema.js";
+
+describe("validateHandlers", () => {
+  it("accepts an empty array", () => {
+    assert.doesNotThrow(() => validateHandlers([]));
+  });
+
+  it("accepts a valid handler entry", () => {
+    assert.doesNotThrow(() =>
+      validateHandlers([{ command: "/usr/bin/handler", types: ["credentials"] }]),
+    );
+  });
+
+  it("accepts a handler with timeout override", () => {
+    assert.doesNotThrow(() =>
+      validateHandlers([{ command: "/usr/bin/handler", types: ["credentials"], timeout: 10000 }]),
+    );
+  });
+
+  it("accepts multiple handlers", () => {
+    assert.doesNotThrow(() =>
+      validateHandlers([
+        { command: "/usr/bin/aws-handler", types: ["credentials"] },
+        { command: "/usr/bin/fallback", types: ["credentials", "region", "instance-id"] },
+      ]),
+    );
+  });
+
+  it("rejects non-array handlers", () => {
+    assert.throws(() => validateHandlers("not-an-array"), /handlers must be an array/);
+  });
+
+  it("rejects handler without command", () => {
+    assert.throws(
+      () => validateHandlers([{ types: ["credentials"] }]),
+      /handlers\[0\]\.command must be a non-empty string/,
+    );
+  });
+
+  it("rejects handler with empty command", () => {
+    assert.throws(
+      () => validateHandlers([{ command: "", types: ["credentials"] }]),
+      /handlers\[0\]\.command must be a non-empty string/,
+    );
+  });
+
+  it("rejects handler with non-string command", () => {
+    assert.throws(
+      () => validateHandlers([{ command: 123, types: ["credentials"] }]),
+      /handlers\[0\]\.command must be a non-empty string/,
+    );
+  });
+
+  it("rejects handler without types", () => {
+    assert.throws(
+      () => validateHandlers([{ command: "/usr/bin/handler" }]),
+      /handlers\[0\]\.types must be a non-empty array of strings/,
+    );
+  });
+
+  it("rejects handler with empty types array", () => {
+    assert.throws(
+      () => validateHandlers([{ command: "/usr/bin/handler", types: [] }]),
+      /handlers\[0\]\.types must be a non-empty array of strings/,
+    );
+  });
+
+  it("rejects handler with non-array types", () => {
+    assert.throws(
+      () => validateHandlers([{ command: "/usr/bin/handler", types: "credentials" }]),
+      /handlers\[0\]\.types must be a non-empty array of strings/,
+    );
+  });
+
+  it("rejects handler with non-string type entry", () => {
+    assert.throws(
+      () => validateHandlers([{ command: "/usr/bin/handler", types: [123] }]),
+      /handlers\[0\]\.types must be a non-empty array of strings/,
+    );
+  });
+
+  it("rejects handler with timeout below 100", () => {
+    assert.throws(
+      () =>
+        validateHandlers([{ command: "/usr/bin/handler", types: ["credentials"], timeout: 50 }]),
+      /handlers\[0\]\.timeout must be an integer between 100 and 30000/,
+    );
+  });
+
+  it("rejects handler with timeout above 30000", () => {
+    assert.throws(
+      () =>
+        validateHandlers([{ command: "/usr/bin/handler", types: ["credentials"], timeout: 60000 }]),
+      /handlers\[0\]\.timeout must be an integer between 100 and 30000/,
+    );
+  });
+
+  it("rejects handler with non-integer timeout", () => {
+    assert.throws(
+      () =>
+        validateHandlers([
+          { command: "/usr/bin/handler", types: ["credentials"], timeout: 5000.5 },
+        ]),
+      /handlers\[0\]\.timeout must be an integer between 100 and 30000/,
+    );
+  });
+
+  it("reports correct index for second handler error", () => {
+    assert.throws(
+      () =>
+        validateHandlers([
+          { command: "/usr/bin/good", types: ["credentials"] },
+          { command: "", types: ["region"] },
+        ]),
+      /handlers\[1\]\.command/,
+    );
+  });
+});

--- a/test/unit/config/loader.test.js
+++ b/test/unit/config/loader.test.js
@@ -384,4 +384,101 @@ describe("config/loader", () => {
       }
     });
   });
+
+  describe("loadConfig - handlers", () => {
+    let tmpDir;
+
+    function setup() {
+      tmpDir = mkdtempSync(join(tmpdir(), "imds-test-"));
+    }
+
+    function teardown() {
+      rmSync(tmpDir, { recursive: true });
+    }
+
+    it("defaults to empty handlers array when no config file", () => {
+      const config = loadConfig({}, cleanEnv);
+      assert.deepEqual(config.handlers, []);
+    });
+
+    it("loads handlers from config file", () => {
+      setup();
+      try {
+        const filePath = join(tmpDir, "config.yml");
+        writeFileSync(
+          filePath,
+          [
+            "handlers:",
+            "  - command: /usr/bin/aws-handler",
+            "    types:",
+            "      - credentials",
+            "  - command: /usr/bin/fallback",
+            "    types:",
+            "      - credentials",
+            "      - region",
+            "",
+          ].join("\n"),
+        );
+        const config = loadConfig({ config: filePath }, cleanEnv);
+        assert.equal(config.handlers.length, 2);
+        assert.equal(config.handlers[0].command, "/usr/bin/aws-handler");
+        assert.deepEqual(config.handlers[0].types, ["credentials"]);
+        assert.equal(config.handlers[1].command, "/usr/bin/fallback");
+        assert.deepEqual(config.handlers[1].types, ["credentials", "region"]);
+      } finally {
+        teardown();
+      }
+    });
+
+    it("loads handler with timeout override", () => {
+      setup();
+      try {
+        const filePath = join(tmpDir, "config.yml");
+        writeFileSync(
+          filePath,
+          [
+            "handlers:",
+            "  - command: /usr/bin/slow-handler",
+            "    types:",
+            "      - credentials",
+            "    timeout: 15000",
+            "",
+          ].join("\n"),
+        );
+        const config = loadConfig({ config: filePath }, cleanEnv);
+        assert.equal(config.handlers[0].timeout, 15000);
+      } finally {
+        teardown();
+      }
+    });
+
+    it("rejects invalid handler in config file", () => {
+      setup();
+      try {
+        const filePath = join(tmpDir, "config.yml");
+        writeFileSync(
+          filePath,
+          ["handlers:", "  - command: /usr/bin/handler", "    types: []", ""].join("\n"),
+        );
+        assert.throws(
+          () => loadConfig({ config: filePath }, cleanEnv),
+          /handlers\[0\]\.types must be a non-empty array/,
+        );
+      } finally {
+        teardown();
+      }
+    });
+
+    it("defaults to empty array when config file has no handlers key", () => {
+      setup();
+      try {
+        const filePath = join(tmpDir, "config.yml");
+        writeFileSync(filePath, "port: 3000\n");
+        const config = loadConfig({ config: filePath }, cleanEnv);
+        assert.deepEqual(config.handlers, []);
+      } finally {
+        teardown();
+      }
+    });
+  });
 });

--- a/test/unit/config/schema.test.js
+++ b/test/unit/config/schema.test.js
@@ -20,8 +20,7 @@ describe("config/schema", () => {
         "tokenTtl",
         "imdsVersion",
         "configFile",
-        "handlerCommand",
-        "handlerCommandTimeout",
+        "handlerTimeout",
         "logLevel",
       ];
       assert.deepStrictEqual(Object.keys(schema).sort(), expectedKeys.sort());
@@ -68,7 +67,7 @@ describe("config/schema", () => {
       const options = buildParseArgsOptions();
       assert.equal(options.port.type, "string");
       assert.equal(options["token-ttl"].type, "string");
-      assert.equal(options["handler-command-timeout"].type, "string");
+      assert.equal(options["handler-timeout"].type, "string");
     });
   });
 
@@ -125,8 +124,7 @@ describe("config/schema", () => {
           tokenTtl: 300,
           imdsVersion: "auto",
           configFile: null,
-          handlerCommand: null,
-          handlerCommandTimeout: 5000,
+          handlerTimeout: 5000,
           logLevel: "info",
         }),
       );
@@ -142,8 +140,7 @@ describe("config/schema", () => {
             tokenTtl: 300,
             imdsVersion: "auto",
             configFile: null,
-            handlerCommand: null,
-            handlerCommandTimeout: 5000,
+            handlerTimeout: 5000,
             logLevel: "info",
           }),
         /port must be an integer between 1 and 65535/,
@@ -160,8 +157,7 @@ describe("config/schema", () => {
             tokenTtl: 300,
             imdsVersion: "auto",
             configFile: null,
-            handlerCommand: null,
-            handlerCommandTimeout: 5000,
+            handlerTimeout: 5000,
             logLevel: "info",
           }),
         /port must be an integer/,
@@ -178,8 +174,7 @@ describe("config/schema", () => {
             tokenTtl: 300,
             imdsVersion: "auto",
             configFile: null,
-            handlerCommand: null,
-            handlerCommandTimeout: 5000,
+            handlerTimeout: 5000,
             logLevel: "verbose",
           }),
         /logLevel must be one of/,
@@ -196,8 +191,7 @@ describe("config/schema", () => {
             tokenTtl: 99999,
             imdsVersion: "auto",
             configFile: null,
-            handlerCommand: null,
-            handlerCommandTimeout: 5000,
+            handlerTimeout: 5000,
             logLevel: "info",
           }),
         /tokenTtl must be an integer between 1 and 21600/,
@@ -214,8 +208,7 @@ describe("config/schema", () => {
             tokenTtl: 300,
             imdsVersion: "auto",
             configFile: null,
-            handlerCommand: null,
-            handlerCommandTimeout: 5000,
+            handlerTimeout: 5000,
             logLevel: "info",
           }),
         /host must be a non-empty string/,
@@ -231,8 +224,7 @@ describe("config/schema", () => {
           tokenTtl: 300,
           imdsVersion: "auto",
           configFile: null,
-          handlerCommand: null,
-          handlerCommandTimeout: 5000,
+          handlerTimeout: 5000,
           logLevel: "info",
         }),
       );


### PR DESCRIPTION
## Summary
- Replace singular `handlerCommand` with a `handlers` array in the YAML config file
- Each handler entry declares a command path, request types, and optional timeout override
- Rename `handlerCommandTimeout` to `handlerTimeout`
- Server auto-loads `~/.imds-server.yml` by default, overridable with `--config`
- Add `config.example.yml` with usage docs and handler authoring guide
- 21 new tests for handler validation and config file loading

Closes #18

## Test plan
- [x] 197 tests passing (16 new handler validation + 5 new loader tests)
- [x] ESLint clean
- [ ] CI passes