### PR TITLE
ci: add Node 24 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add Node 24 (LTS since Oct 2025, EOL April 2028) to the CI test matrix
- Currently tested: 20, 22. Now: 20, 22, 24

## Test plan
- [ ] CI passes on all three Node versions