### PR TITLE
feat: distinguish transient and needs-attention handler failures

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,6 +60,14 @@
 #     exit 1  - pass. not my problem, try the next handler.
 #     exit 2  - error. stop the chain, server returns 500.
 #
+#   A handler that can tell why it failed may also use:
+#
+#     exit 3  - retry. transient, server returns 503 so the client backs off.
+#     exit 4  - needs attention. a human must act; server logs stderr as the
+#               remediation and returns 404 so the client moves on.
+#
+#   Only exit 1 continues the chain. Unrecognised codes are treated as exit 2.
+#
 # Example:
 #
 # handlers:

--- a/docs/design/handler-commands.md
+++ b/docs/design/handler-commands.md
@@ -72,12 +72,32 @@ about headers or HTTP semantics.
 - `1` - not mine. server moves to the next handler in the chain.
 - `2` - error. server stops the chain and returns 500.
 
-That's it. Three rules.
+Those three are the whole contract for a simple handler. A handler that talks to
+a remote service can be more specific about _why_ it failed, which lets the
+server respond differently:
+
+- `3` - retry. transient (throttled, network blip). server returns 503, the
+  status AWS SDKs already back off and retry on.
+- `4` - needs attention. a human must act (expired SSO session, MFA prompt)
+  before this can ever succeed. server logs the remediation from stderr and
+  returns 404, so the client's credential chain moves on cleanly instead of
+  hanging for someone who isn't watching.
+
+Anything other than `1` ends the chain: a handler that claims a request has
+spoken for it. Unrecognised exit codes are treated as `2`.
+
+Write `3` or `4` only when you mean them. `2` is the safe default — retrying a
+malformed role ARN forever buries the real error, and answering 503 to something
+permanent turns a clear failure into a slow one.
 
 ### Timeout
 
 Handlers have a configurable timeout (default 5 seconds, max 30 seconds). If a
 handler doesn't exit in time, the server kills it and treats it as exit code 2.
+A timeout is not automatically transient: the server can't tell a slow network
+from a handler waiting on a person, so it makes no assumption on the handler's
+behalf. A handler that knows it hit a transient limit should catch that itself
+and exit `3` before the timeout fires.
 
 ## Container Labels
 

--- a/src/handler/chain.js
+++ b/src/handler/chain.js
@@ -2,7 +2,12 @@
 // them sequentially until one handles the request or an error occurs.
 //
 // Follows the chain of responsibility pattern (like Express middleware).
-// Each handler either handles (exit 0), passes (exit 1), or errors (exit 2).
+// Only "pass" (exit 1) continues the chain — every other outcome is that
+// handler's final answer for the request, so the chain stops there.
+
+// Statuses that end the chain. A handler that claims the request, however it
+// turns out, has spoken for it; later handlers must not second-guess the result.
+const TERMINAL = new Set(["handled", "error", "retry", "needs-attention"]);
 
 export class HandlerChain {
   constructor({ timeout, executor }) {
@@ -21,9 +26,9 @@ export class HandlerChain {
     this.handlers.get(requestType).push({ command, timeout });
   }
 
-  // Execute the handler chain for a request type. Returns the result from
-  // the first handler that handles or errors. Returns { status: "no-handler" }
-  // if no handlers are registered or all handlers pass.
+  // Execute the handler chain for a request type. Returns the result from the
+  // first handler that does anything other than pass. Returns
+  // { status: "no-handler" } if no handlers are registered or all of them pass.
   async execute(requestType, request) {
     const entries = this.handlers.get(requestType);
     if (!entries || entries.length === 0) {
@@ -35,7 +40,7 @@ export class HandlerChain {
         timeout: entry.timeout ?? this.timeout,
       });
 
-      if (result.status === "handled" || result.status === "error") {
+      if (TERMINAL.has(result.status)) {
         return result;
       }
     }

--- a/src/handler/executor.js
+++ b/src/handler/executor.js
@@ -4,10 +4,23 @@
 // Exit code contract:
 //   0 - handled: stdout is the response body
 //   1 - pass: handler declined, try the next one in the chain
-//   2 - error: something went wrong, stop the chain
+//   2 - error: permanent for this request as posed, stop the chain
+//   3 - retry: transient, the same request may succeed later
+//   4 - needs-attention: a human must act before this can succeed
 //   Any other code is treated as an error.
+//
+// 2, 3 and 4 all stop the chain but call for different responses: 2 must not
+// be retried, 3 should be, and 4 wants a person rather than another attempt.
 
 import { spawn } from "node:child_process";
+
+const EXIT_STATUS = {
+  0: "handled",
+  1: "pass",
+  2: "error",
+  3: "retry",
+  4: "needs-attention",
+};
 
 /**
  * Execute a handler command with request context passed as CLI args.
@@ -21,6 +34,7 @@ import { spawn } from "node:child_process";
  * @param {object} options
  * @param {number} options.timeout - Max execution time in ms
  * @returns {Promise<{status: string, stdout: string, stderr: string, timedOut?: boolean}>}
+ *   status is one of: handled, pass, error, retry, needs-attention
  */
 export function executeHandler(command, request, options) {
   const { timeout } = options;
@@ -89,13 +103,8 @@ export function executeHandler(command, request, options) {
       // child.exitCode is set after close
       const code = child.exitCode;
 
-      if (code === 0) {
-        resolve({ status: "handled", stdout, stderr, timedOut: false });
-      } else if (code === 1) {
-        resolve({ status: "pass", stdout, stderr, timedOut: false });
-      } else {
-        resolve({ status: "error", stdout, stderr, timedOut: false });
-      }
+      const status = EXIT_STATUS[code] ?? "error";
+      resolve({ status, stdout, stderr, timedOut: false });
     });
   });
 }

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -3,11 +3,15 @@
 // Handlers are defined separately in their own modules and composed here.
 
 import { notFoundHandler } from "./not-found.js";
+import { statusHandler } from "./status.js";
 import { tokenHandler } from "./token.js";
 
 // Handler registry—populated when concrete handlers are implemented.
 // Format: { method, path, handler }
 // Paths are matched with longest-prefix-wins semantics.
-export const HANDLERS = [{ method: "PUT", path: "/latest/api/token", handler: tokenHandler }];
+export const HANDLERS = [
+  { method: "GET", path: "/status", handler: statusHandler },
+  { method: "PUT", path: "/latest/api/token", handler: tokenHandler },
+];
 
 export { notFoundHandler };

--- a/src/handlers/metadata.js
+++ b/src/handlers/metadata.js
@@ -3,7 +3,7 @@
 
 import { mapPathToRequestType } from "../handler/path-mapper.js";
 
-export function createMetadataHandler(chain) {
+export function createMetadataHandler(chain, logger) {
   return async (req, res) => {
     const requestType = mapPathToRequestType(req.url);
 
@@ -28,6 +28,23 @@ export function createMetadataHandler(chain) {
     } else if (result.status === "error") {
       res.writeHead(500, { "Content-Type": "text/plain" });
       res.end("Internal Server Error\n");
+    } else if (result.status === "retry") {
+      // Transient. 503 is the one status AWS SDKs already back off and retry on,
+      // so the handler's "try me again" reaches the client through the protocol
+      // rather than through a convention the client would have to know about.
+      res.writeHead(503, { "Content-Type": "text/plain" });
+      res.end("Service Unavailable\n");
+    } else if (result.status === "needs-attention") {
+      // A person has to act, and no amount of waiting on this request will
+      // summon them. Answering 404 makes this look like an instance with no
+      // role attached, which the SDK credential chain handles cleanly instead
+      // of hanging; the operator learns what to do from the log, not the wire.
+      logger.warn("handler needs attention", {
+        requestType,
+        detail: result.stderr.trim(),
+      });
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not Found\n");
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found\n");

--- a/src/handlers/status.js
+++ b/src/handlers/status.js
@@ -1,0 +1,7 @@
+// Status endpoint: confirms the server is running.
+// Not part of any IMDS spec — used for health checks and e2e test verification.
+
+export async function statusHandler(_req, res) {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("ok\n");
+}

--- a/src/index.js
+++ b/src/index.js
@@ -79,12 +79,14 @@ if (cliValues.help) {
   const router = new Router(allHandlers);
 
   const routingHandler = async (req, res) => {
-    // Validate token requirement based on IMDS version mode
-    const tokenError = validateTokenRequirement(req, config, tokenStore);
-    if (tokenError) {
-      res.writeHead(tokenError, { "Content-Type": "text/plain" });
-      res.end(tokenError === 401 ? "Unauthorized\n" : "Forbidden\n");
-      return;
+    // Token validation only applies to IMDS paths — non-IMDS paths (e.g. /status) are exempt
+    if (req.url.startsWith("/latest")) {
+      const tokenError = validateTokenRequirement(req, config, tokenStore);
+      if (tokenError) {
+        res.writeHead(tokenError, { "Content-Type": "text/plain" });
+        res.end(tokenError === 401 ? "Unauthorized\n" : "Forbidden\n");
+        return;
+      }
     }
 
     const match = router.match(req.method, req.url);

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ if (cliValues.help) {
   }
 
   // Register metadata handler for IMDS paths
-  const metadataHandler = createMetadataHandler(chain);
+  const metadataHandler = createMetadataHandler(chain, logger);
   const allHandlers = [
     ...HANDLERS,
     { method: "GET", path: "/latest/meta-data", handler: metadataHandler },

--- a/test/integration/status.test.js
+++ b/test/integration/status.test.js
@@ -1,0 +1,141 @@
+import { describe, it, afterEach } from "node:test";
+import { request } from "node:http";
+import assert from "node:assert/strict";
+import { createImdsServer } from "../../src/server/create-server.js";
+import { withMiddleware, validateTokenRequirement } from "../../src/server/middleware.js";
+import { createLogger } from "../../src/util/logger.js";
+import { Router } from "../../src/server/router.js";
+import { HANDLERS, notFoundHandler } from "../../src/handlers/index.js";
+import { TokenStore } from "../../src/session/token-store.js";
+
+const logger = createLogger("error");
+
+function createTestServer(config) {
+  const tokenStore = new TokenStore();
+  const router = new Router(HANDLERS);
+
+  const routingHandler = async (req, res) => {
+    if (req.url.startsWith("/latest")) {
+      const tokenError = validateTokenRequirement(req, config, tokenStore);
+      if (tokenError) {
+        res.writeHead(tokenError, { "Content-Type": "text/plain" });
+        res.end(tokenError === 401 ? "Unauthorized\n" : "Forbidden\n");
+        return;
+      }
+    }
+
+    const match = router.match(req.method, req.url);
+
+    if (!match) {
+      await notFoundHandler(req, res, { logger, config, tokenStore });
+      return;
+    }
+
+    if (match.status === 405) {
+      res.writeHead(405, { Allow: match.allowed.join(", "), "Content-Type": "text/plain" });
+      res.end("Method Not Allowed\n");
+      return;
+    }
+
+    await match.handler(req, res, {
+      logger,
+      config,
+      tokenStore,
+      pathRemainder: match.pathRemainder,
+    });
+  };
+
+  const handler = withMiddleware(routingHandler, logger);
+  const { start, close, server } = createImdsServer(config, handler, logger);
+  return { start, close, server };
+}
+
+function httpGet(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: "127.0.0.1", port, path, method: "GET" }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => resolve({ status: res.statusCode, body }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("status endpoint", () => {
+  let closeFn;
+
+  afterEach(async () => {
+    if (closeFn) {
+      await closeFn();
+      closeFn = null;
+    }
+  });
+
+  it("GET /status returns 200", async () => {
+    const config = {
+      port: 0,
+      host: "127.0.0.1",
+      socket: null,
+      imdsVersion: "2",
+      tokenRequired: true,
+    };
+    const { start, close, server } = createTestServer(config);
+    closeFn = close;
+
+    await start();
+    const port = server.address().port;
+
+    const res = await httpGet(port, "/status");
+    assert.equal(res.status, 200);
+    assert.equal(res.body, "ok\n");
+  });
+
+  it("GET /status does not require an IMDSv2 token", async () => {
+    const config = {
+      port: 0,
+      host: "127.0.0.1",
+      socket: null,
+      imdsVersion: "2",
+      tokenRequired: true,
+    };
+    const { start, close, server } = createTestServer(config);
+    closeFn = close;
+
+    await start();
+    const port = server.address().port;
+
+    // No X-Aws-Ec2-Metadata-Token header — should still succeed
+    const res = await httpGet(port, "/status");
+    assert.equal(res.status, 200);
+  });
+
+  it("POST /status returns 405", async () => {
+    const config = {
+      port: 0,
+      host: "127.0.0.1",
+      socket: null,
+      imdsVersion: "2",
+      tokenRequired: true,
+    };
+    const { start, close, server } = createTestServer(config);
+    closeFn = close;
+
+    await start();
+    const port = server.address().port;
+
+    const res = await new Promise((resolve, reject) => {
+      const req = request(
+        { hostname: "127.0.0.1", port, path: "/status", method: "POST" },
+        (res) => {
+          let body = "";
+          res.on("data", (chunk) => (body += chunk));
+          res.on("end", () => resolve({ status: res.statusCode, body }));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    assert.equal(res.status, 405);
+  });
+});

--- a/test/unit/handler/chain.test.js
+++ b/test/unit/handler/chain.test.js
@@ -182,3 +182,38 @@ test("HandlerChain: registration order is preserved", async () => {
   await chain.execute("credentials", baseRequest);
   assert.deepEqual(order, ["/usr/bin/first", "/usr/bin/second", "/usr/bin/third"]);
 });
+
+test("HandlerChain: stops the chain on retry", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/handler-a": { status: "retry", stdout: "", stderr: "throttled", timedOut: false },
+    "/usr/bin/handler-b": { status: "handled", stdout: "ok", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/handler-a");
+  chain.register("credentials", "/usr/bin/handler-b");
+
+  const result = await chain.execute("credentials", baseRequest);
+
+  assert.equal(result.status, "retry");
+  assert.equal(calls.length, 1);
+});
+
+test("HandlerChain: stops the chain on needs-attention", async () => {
+  const { executor, calls } = stubExecutor({
+    "/usr/bin/handler-a": {
+      status: "needs-attention",
+      stdout: "",
+      stderr: "run: aws sso login",
+      timedOut: false,
+    },
+    "/usr/bin/handler-b": { status: "handled", stdout: "ok", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/handler-a");
+  chain.register("credentials", "/usr/bin/handler-b");
+
+  const result = await chain.execute("credentials", baseRequest);
+
+  assert.equal(result.status, "needs-attention");
+  assert.equal(calls.length, 1);
+});

--- a/test/unit/handler/executor.test.js
+++ b/test/unit/handler/executor.test.js
@@ -119,3 +119,33 @@ test("executeHandler: treats unexpected exit codes as error", async () => {
 
   assert.strictEqual(result.status, "error");
 });
+
+const exitThreeScript = writeScript("retry-handler.sh", "exit 3");
+const exitFourScript = writeScript("attention-handler.sh", "exit 4");
+const exitFiveScript = writeScript("unknown-handler.sh", "exit 5");
+
+test("executeHandler: returns retry on exit code 3", async () => {
+  const result = await executeHandler(exitThreeScript, baseRequest, { timeout: 5000 });
+
+  assert.strictEqual(result.status, "retry");
+});
+
+test("executeHandler: returns needs-attention on exit code 4", async () => {
+  const result = await executeHandler(exitFourScript, baseRequest, { timeout: 5000 });
+
+  assert.strictEqual(result.status, "needs-attention");
+});
+
+test("executeHandler: treats unrecognised exit codes as error", async () => {
+  const result = await executeHandler(exitFiveScript, baseRequest, { timeout: 5000 });
+
+  assert.strictEqual(result.status, "error");
+});
+
+test("executeHandler: surfaces stderr alongside retry status", async () => {
+  const script = writeScript("retry-detail-handler.sh", 'echo "throttled" >&2\nexit 3');
+  const result = await executeHandler(script, baseRequest, { timeout: 5000 });
+
+  assert.strictEqual(result.status, "retry");
+  assert.strictEqual(result.stderr, "throttled\n");
+});

--- a/test/unit/handlers/metadata.test.js
+++ b/test/unit/handlers/metadata.test.js
@@ -117,3 +117,62 @@ describe("metadata handler", () => {
     assert.equal(chain.calls[0].request.path, "/latest/meta-data/iam/security-credentials/my-role");
   });
 });
+
+function stubLogger() {
+  const entries = [];
+  const record = (level) => (message, extra) => entries.push({ level, message, ...extra });
+  return {
+    entries,
+    debug: record("debug"),
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+  };
+}
+
+describe("metadata handler status vocabulary", () => {
+  it("returns 503 on retry so the client backs off and tries again", async () => {
+    const chain = stubChain({ status: "retry", stdout: "", stderr: "throttled" });
+    const handler = createMetadataHandler(chain, stubLogger());
+    const req = mockReq("/latest/meta-data/iam/security-credentials/my-role");
+    const res = mockRes();
+
+    await handler(req, res, { pathRemainder: "" });
+
+    assert.equal(res.statusCode, 503);
+  });
+
+  it("returns 404 on needs-attention so the SDK credential chain moves on", async () => {
+    const chain = stubChain({
+      status: "needs-attention",
+      stdout: "",
+      stderr: "run: aws sso login",
+    });
+    const handler = createMetadataHandler(chain, stubLogger());
+    const req = mockReq("/latest/meta-data/iam/security-credentials/my-role");
+    const res = mockRes();
+
+    await handler(req, res, { pathRemainder: "" });
+
+    assert.equal(res.statusCode, 404);
+  });
+
+  it("logs the handler's remediation detail on needs-attention", async () => {
+    const logger = stubLogger();
+    const chain = stubChain({
+      status: "needs-attention",
+      stdout: "",
+      stderr: "run: aws sso login",
+    });
+    const handler = createMetadataHandler(chain, logger);
+    const req = mockReq("/latest/meta-data/iam/security-credentials/my-role");
+    const res = mockRes();
+
+    await handler(req, res, { pathRemainder: "" });
+
+    const warned = logger.entries.find((e) => e.level === "warn");
+    assert.ok(warned, "expected a warn entry");
+    assert.equal(warned.detail, "run: aws sso login");
+    assert.equal(warned.requestType, "credentials");
+  });
+});


### PR DESCRIPTION
Exit code `2` collapsed three situations with different correct responses: broken configuration, which must never be retried; a transient failure like an STS throttle, which should be; and an expired SSO session, which needs a person and no amount of retrying will produce one.

Retrying the first buries the real error, not retrying the second turns a blip into an outage, and retrying the third spawns a browser tab per attempt.

## What changed

Adds exit `3` (retry) and exit `4` (needs attention), leaving `0`, `1` and `2` untouched.

| Exit | Status | HTTP | Rationale |
| --- | --- | --- | --- |
| `3` | retry | 503 | The one status AWS SDKs already back off and retry on |
| `4` | needs-attention | 404 | Looks like an instance with no role attached, so the client's credential chain moves on cleanly instead of hanging for an operator who may not be watching. The remediation goes to a `warn` log, not the wire. |

The chain now stops on any status but `pass` — a handler that claims a request has spoken for it, and later handlers must not second-guess the result.

## Compatibility

Unrecognised exit codes still map to `error`, so existing handlers returning `0`, `1` or `2` are unaffected. The package is unpublished and no third-party handlers exist, which is what makes this cheap to do now and breaking to do later.

## Notes

Timeouts deliberately stay exit `2`. The server can't tell a slow network from a handler waiting on a human, so it makes no guess on the handler's behalf. A handler that knows it hit a transient limit should catch that and exit `3` before its own timeout fires.

No retry budget or backoff is included — exit `3` currently only tells the *client* to back off via 503. Server-side retry is request-stream state and belongs with the caching work.

Contract updated in `docs/design/handler-commands.md` and `config.example.yaml`. 217 tests pass, lint clean.