### PR TITLE
docs: AWS handler design, label namespacing, and handler state ownership

### DIFF
--- a/docs/design/handler-aws.md
+++ b/docs/design/handler-aws.md
@@ -1,0 +1,252 @@
+# handler-aws design
+
+Separate npm package (`@imdsutil/imds-handler-aws`) that ships as an executable
+handler command for imds-server. Handles AWS credential resolution for
+opted-in containers running on a developer's local machine.
+
+## Scope
+
+imds-server is a desktop tool. This handler targets local dev workflows only.
+It is not intended for deployment into cloud environments.
+
+## How it fits in
+
+Users install the package, then reference the bin in `~/.imds-server.yml`:
+
+```yaml
+handlers:
+  - command: imds-handler-aws
+    types:
+      - credentials
+```
+
+The server spawns the handler per request with container context as CLI args.
+The handler resolves credentials and writes IMDS-format JSON to stdout.
+
+## Credential scenarios
+
+### Group 1: Static credentials
+
+Simplest path. Useful for solo devs with a single set of IAM user credentials.
+
+**1a. Global static credentials**
+All opted-in containers get the same key/secret. Configured in the handler's
+own config (or env vars). No per-container labels needed beyond
+`imds.aws.ambient: "true"` or another AWS opt-in label.
+
+**1b. Per-container static credentials**
+Different key/secret per container via labels:
+
+- `imds.aws.access-key-id`
+- `imds.aws.secret-access-key`
+- `imds.aws.session-token` (optional, for pre-assumed role creds)
+
+Frowned upon for services but common in dev. We support it without judgment.
+
+### Group 2: Named AWS profile
+
+Reads from `~/.aws/credentials` and `~/.aws/config`. Profile name comes from
+the `imds.aws.profile` container label, or falls back to a configured default.
+
+**2a. Static credentials profile**
+Profile has `aws_access_key_id` and `aws_secret_access_key`. Handler resolves
+and returns directly.
+
+**2b. Role profile**
+Profile has `role_arn` and `source_profile`. SDK handles the assume-role
+automatically. Handler just resolves the profile.
+
+**2c. SSO profile**
+Profile backed by IAM Identity Center (AWS SSO). The dominant corporate
+pattern. Session expires regularly and requires re-authentication.
+
+When `autoSsoLogin: true` is set in handler config (default: false), the
+handler detects the SSO expiry error, spawns `aws sso login --profile <name>`,
+and blocks until the user approves in the browser. The browser tab opens
+automatically via the system (`open` on macOS, `xdg-open` on Linux). After
+approval the handler retries credential resolution and returns creds.
+
+When `autoSsoLogin: false`, handler exits 2 with a clear message telling the
+user to run `aws sso login --profile <name>` manually.
+
+**Caveats for autoSsoLogin:**
+
+- Handlers using this feature need a high timeout in `~/.imds-server.yml`
+  (e.g. `timeout: 120000`). The default 5s ceiling is not enough for a human
+  to approve a browser flow.
+- If imds-server runs as root (e.g. `sudo` to bind port 80), the handler
+  inherits the root context. On Linux, `sudo` strips desktop session env vars
+  (`DISPLAY`, `DBUS_SESSION_BUS_ADDRESS`) so `xdg-open` may not find the
+  browser. macOS is unaffected. Workaround: run imds-server on a
+  non-privileged port or via a unix socket to avoid needing sudo.
+
+**2d. credential_process profile**
+Profile delegates to an external command via `credential_process`. Covers:
+
+- aws-vault
+- Leapp
+- 1Password CLI (`op run`)
+- Any custom secret fetcher
+
+SDK handles this automatically via the credential provider chain — effectively
+free once profile resolution is wired up.
+
+### Group 3: Role assumption
+
+`imds.aws.role` label contains the role ARN to assume. The caller identity is
+resolved from the credential chain (profile, ambient env, etc.).
+
+**3a. AssumeRole with ambient caller**
+Caller resolved from default credential chain (env vars → default profile →
+credential_process). Most common use case for developers who have a working
+AWS CLI setup and just want to assume a project role.
+
+**3b. AssumeRole with named profile as caller**
+`imds.aws.profile` selects the caller identity, `imds.aws.role` is the role to
+assume. Useful for multi-account setups where the user has a base identity
+in one account and assumes roles in others.
+
+**3c. AssumeRole with static caller credentials**
+Labels provide both the caller creds and the role ARN. Niche but supported
+as a combination of group 1b + group 3.
+
+**3d. Multi-hop role chaining**
+Assume role A, use those creds to assume role B. Corporate landing zones with
+org account structures (dev/staging/prod accounts) require this regularly.
+AWS allows up to 5 hops. Supported by configuring a chain of role ARNs, or
+by relying on a profile that already has chaining configured.
+
+**3e. AssumeRole with External ID**
+Some roles have a trust policy requiring an `ExternalId` condition. Common in
+cross-account setups and third-party access patterns. Configurable per handler
+or per container label (`imds.aws.external-id`).
+
+**3f. AssumeRole with MFA**
+Some roles require MFA serial + token. TOTP can be automated if the user
+provides a TOTP secret. At minimum, handler should detect the MFA required
+error and exit 2 with a clear message. Auto-TOTP is a stretch goal.
+
+### Group 4: Ambient passthrough
+
+No role assumption. Handler resolves whatever the default credential chain
+returns and passes it through as IMDS credentials. Useful for developers whose
+host machine already has the right identity (SSO session, env vars, etc.) and
+they just want containers to inherit it.
+
+Opt-in via `imds.aws.ambient: "true"` label.
+
+## Container opt-in
+
+Containers must opt in. The handler exits 1 (pass) if no AWS label is present,
+letting the next handler try.
+
+Opt-in signals (evaluated in order):
+
+1. `imds.aws.role` — present → group 3 (role assumption)
+2. `imds.aws.profile` — present → group 2 (profile resolution)
+3. `imds.aws.access-key-id` — present → group 1b (per-container static creds)
+4. `imds.aws.ambient: "true"` + global static creds in handler config → group 1a
+5. `imds.aws.ambient: "true"` alone → group 4 (ambient passthrough)
+6. None of the above → exit 1
+
+## Role ARN source
+
+For group 3, the role ARN can come from:
+
+- `imds.aws.role` container label (primary)
+- Handler config as a global default role (fallback)
+
+## STS options
+
+Configurable at the handler level, overridable per container via labels where
+it makes sense:
+
+| Option                | Label                       | Config key        | Default                        |
+| --------------------- | --------------------------- | ----------------- | ------------------------------ |
+| Session name          | —                           | `sessionName`     | `imds-server-{container-name}` |
+| Session duration      | `imds.aws.session-duration` | `sessionDuration` | `3600`                         |
+| External ID           | `imds.aws.external-id`      | `externalId`      | —                              |
+| Role ARN              | `imds.aws.role`             | `defaultRole`     | —                              |
+| STS regional endpoint | —                           | `stsRegion`       | `us-east-1`                    |
+| Custom STS endpoint   | —                           | `stsEndpoint`     | —                              |
+
+## Credential caching
+
+The handler is spawned per request. Without caching, multiple containers
+requesting credentials simultaneously will each make an STS AssumeRole call.
+STS has rate limits, and round-trip latency adds up.
+
+Handler should cache resolved credentials (keyed on role ARN + profile + caller
+identity) and return cached creds until 5 minutes before expiry. Cache lives in
+a temp file (e.g. `~/.cache/imds-handler-aws/`) so it survives across
+invocations without an in-process cache.
+
+## Handler config file
+
+Handler reads its own config from `~/.imds-handler-aws.yml` (auto-loaded) or
+`--config` override. Keys live under a flat namespace:
+
+```yaml
+# Default profile to use when imds.aws.profile label is not set
+# defaultProfile: default
+
+# Global static credentials (all opted-in containers)
+# accessKeyId: AKIA...
+# secretAccessKey: ...
+
+# Global default role ARN (used when imds.aws.role label is not set but container
+# has opted in via another signal)
+# defaultRole: arn:aws:iam::123456789012:role/dev
+
+# Session name template. {container-name} is replaced at runtime.
+# sessionName: "imds-server-{container-name}"
+
+# Automatically run `aws sso login` when an SSO session is expired.
+# Requires a high timeout on the handler entry in ~/.imds-server.yml (e.g. 120000ms).
+# Not recommended if imds-server runs as root on Linux (browser may not open).
+# autoSsoLogin: false
+
+# Session duration in seconds (900-43200)
+# sessionDuration: 3600
+
+# STS region (determines which regional endpoint is used)
+# stsRegion: us-east-1
+
+# Custom STS endpoint (for GovCloud, China, or corporate proxy)
+# stsEndpoint: https://sts.us-gov-west-1.amazonaws.com
+```
+
+## Package structure
+
+```
+handler-aws/
+  bin/
+    imds-handler-aws.js   # entry point, thin CLI wrapper
+  src/
+    config.js             # config loader
+    resolve.js            # credential resolution decision tree
+    sts.js                # STS AssumeRole wrapper
+    cache.js              # credential cache (temp file)
+    format.js             # format resolved creds as IMDS JSON
+  test/
+    ...
+  package.json
+```
+
+## Error handling
+
+| Condition                | Exit code | stderr                                       |
+| ------------------------ | --------- | -------------------------------------------- |
+| No opt-in signal         | 1         | —                                            |
+| SSO session expired      | 2         | Clear message + `aws sso login` command      |
+| MFA required             | 2         | Clear message with serial and instructions   |
+| STS access denied        | 2         | AWS error message                            |
+| Config file not found    | —         | Optional; all settings fall back to defaults |
+| Invalid config           | 2         | Specific validation error                    |
+| Credential cache corrupt | —         | Silently discard, re-resolve                 |
+
+## Dependencies
+
+- `@aws-sdk/client-sts` — AssumeRole
+- `@aws-sdk/credential-providers` — profile, SSO, credential_process, ambient chain
+- `yaml` — config file parsing

--- a/docs/design/handler-commands.md
+++ b/docs/design/handler-commands.md
@@ -51,7 +51,7 @@ Example:
 my-handler --path /latest/meta-data/iam/security-credentials/my-role \
            --container-id abc123 \
            --container-name my-app \
-           --container-labels '{"imds.role":"arn:aws:iam::123456:role/dev"}'
+           --container-labels '{"imds.aws.role":"arn:aws:iam::123456:role/dev"}'
 ```
 
 stdin piping may be added later for handlers that need to receive larger
@@ -85,19 +85,20 @@ For built-in handlers, the label convention is `imds.*`. The server and proxy
 don't prescribe label names beyond `imds-proxy.enabled` (which is a proxy-side
 concern, not a server concern).
 
-For role/identity mapping, built-in handlers use `imds.role`. The value is
-provider-specific but the concept is the same across clouds: "assume this
-identity for this container."
+For role/identity mapping, built-in handlers namespace the label by provider:
+`imds.<provider>.role`. The concept is the same across clouds ("assume this
+identity for this container"), but each provider gets its own label so a
+container can opt in to more than one handler without collision.
 
 ```bash
 # AWS
-docker run --label imds.role=arn:aws:iam::123456:role/my-role ...
+docker run --label imds.aws.role=arn:aws:iam::123456:role/my-role ...
 
 # GCP
-docker run --label imds.role=my-sa@project.iam.gserviceaccount.com ...
+docker run --label imds.gcp.role=my-sa@project.iam.gserviceaccount.com ...
 
 # Azure
-docker run --label imds.role=/subscriptions/.../my-identity ...
+docker run --label imds.azure.role=/subscriptions/.../my-identity ...
 ```
 
 Custom handlers can use whatever labels they want. The full label set is passed
@@ -107,7 +108,7 @@ through as JSON.
 
 The project will ship working handler implementations for common use cases:
 
-- **AWS STS** - AssumeRole using `imds.role` label value, returns IMDS
+- **AWS STS** - AssumeRole using `imds.aws.role` label value, returns IMDS
   credential format
 - **GCP** - Service account token exchange
 - **Azure** - Managed identity token acquisition
@@ -148,7 +149,7 @@ That's a working credentials handler. `chmod +x`, point the config at it, done.
 # only-handles-prod-role.sh
 
 LABELS="$4"  # container-labels arg
-ROLE=$(echo "$LABELS" | jq -r '.["imds.role"]')
+ROLE=$(echo "$LABELS" | jq -r '.["imds.aws.role"]')
 
 if [ "$ROLE" != "arn:aws:iam::123456:role/prod" ]; then
   exit 1  # not mine

--- a/docs/design/handler-state-ownership.md
+++ b/docs/design/handler-state-ownership.md
@@ -1,0 +1,250 @@
+# Handler state ownership
+
+Status: proposal. Amends `handler-commands.md` and `handler-aws.md`.
+
+## Overview
+
+`handler-commands.md` commits to an extension model whose stated goal is the
+lowest possible barrier to entry: "a working handler can be a three-line bash
+script." `handler-aws.md` then places a credential cache inside the AWS handler,
+at `~/.cache/imds-handler-aws/`.
+
+Those two decisions are in conflict. This note argues that the conflict resolves
+in favour of the protocol — the extension model is sound — and that the cache
+must move to the server. It then works through what that implies for the
+protocol, because the current contract cannot support a server-side cache
+without changing.
+
+## The principle
+
+A handler is spawned per request, answers one question, and exits. It sees a
+single request. It never sees the request _stream_.
+
+Caching, in-flight deduplication, background refresh, and rate limiting are all
+properties of a request stream. None of them can be implemented correctly by a
+process that observes one request in isolation.
+
+> **A handler is a pure function from container context to credentials. Every
+> stateful concern belongs to the server.**
+
+This is not a constraint the protocol imposes reluctantly. It is what makes the
+three-line bash script viable: the script has no state to manage because state
+was never its job.
+
+## 1. The credential cache belongs to the server
+
+`handler-aws.md` specifies a file-backed cache keyed on role ARN + profile +
+caller identity, living in `~/.cache/imds-handler-aws/`. The key design is
+right. The location is not.
+
+**The pluggability argument.** If the cache lives in the handler, then every
+handler needs one. A GCP handler, an Azure handler, and a corporate-internal
+handler each have to implement TTL handling, single-flight, stale-while-
+revalidate, and negative caching — independently, in whatever language they were
+written in. The three-line bash script cannot do any of it. The barrier to entry
+we advertise is not the barrier we would actually be imposing.
+
+**The correctness argument.** A per-request process cannot deduplicate against
+its own siblings. Twelve containers starting together spawn twelve handler
+processes; nothing in that picture can collapse them into one `AssumeRole` call,
+because no participant knows the others exist. The usual fix is a lock file, at
+which point we have a distributed-systems problem in a directory, with stale
+locks surviving `SIGKILL` as the reward.
+
+**The uniformity argument.** One cache in the server means one implementation to
+get right, one place to audit for credential leakage, one place to instrument,
+and consistent `imds-server` status output across every handler regardless of who
+wrote it.
+
+**Proposed change.** Remove `cache.js` from the handler package structure in
+`handler-aws.md`. Move the credential cache into the server, applying uniformly
+to every handler in the chain. The handler keeps whatever internal caching its
+own dependencies do — the AWS SDK's SSO token cache on disk, for instance — which
+is invisible to the server and none of its business.
+
+## 2. A server-side cache requires the server to read the expiry
+
+This is the part that costs something, and it should be decided deliberately
+rather than waved through.
+
+`handler-commands.md` currently says:
+
+> The server treats stdout as the response body and sends it directly to the
+> client.
+
+An opaque byte stream cannot be cached. The server has no way to learn when the
+credentials it just relayed expire, so it cannot decide when to evict, when to
+refresh early, or whether what it holds is still safe to serve. Server-side
+caching is impossible under the current contract, whatever we do elsewhere.
+
+Three ways out:
+
+**(a) A response envelope.** The handler returns structured JSON that the server
+unwraps and renders:
+
+```json
+{
+  "version": 1,
+  "status": "ok",
+  "credentials": {
+    "access_key_id": "ASIA...",
+    "secret_access_key": "...",
+    "session_token": "...",
+    "expiration": "2026-08-23T18:00:00Z"
+  },
+  "identity": { "account": "111122223333", "region": "eu-west-1" },
+  "cache": { "key": "aws:1111:role/billing:acme-dev" }
+}
+```
+
+Cleanest, and it has a second benefit: rendering moves to the server, so a
+handler for a provider whose wire format is not AWS-shaped — a GCP handler
+returning a bearer token — stops having to pretend. The cost is that the trivial
+handler now emits an envelope rather than the literal response body, and
+`format.js` moves from the AWS handler into the server.
+
+**(b) Content-type-aware sniffing.** The server already knows the request type is
+`credentials`, so it could parse the IMDS credential JSON it receives and read
+`Expiration`. No protocol change; handlers stay unchanged. The cost is that the
+server acquires per-request-type parsing of formats it currently treats as
+opaque, and the "handlers own their response body" property quietly dies anyway
+— less visibly, and only for the types we special-case.
+
+**(c) Sidecar metadata.** Body on stdout as today, cache metadata on fd 3 or as a
+trailing line. Preserves the current contract for simple handlers and is
+opt-in. It is also the fiddliest to specify and the easiest to get wrong in a
+shell script.
+
+**Recommendation: (a).** It is the only option that stays honest about what the
+server is doing, and the multi-cloud rendering benefit is real given the stated
+intent to ship GCP and Azure handlers. But it is a breaking protocol change, and
+it is the decision in this note I hold most loosely. (b) is a legitimate
+near-term compromise if we want caching before we want a stable third-party
+contract.
+
+## 3. The status vocabulary is too narrow
+
+Current contract:
+
+- `0` — handled, stdout is the response body
+- `1` — not mine, try the next handler
+- `2` — error, stop the chain and return 500
+
+The `0`/`1` split is good and should be kept. Distinguishing "not mine" from
+"broken" lets the server render "no role attached" — indistinguishable from an
+EC2 instance with no instance profile, so the SDK chain proceeds normally —
+separately from a genuine failure. It is worth stating explicitly that this was
+the right call.
+
+`2` is doing too much. It currently collapses three situations with completely
+different correct responses:
+
+| Situation                                   | Correct server behaviour              | Today |
+| ------------------------------------------- | ------------------------------------- | ----- |
+| Config is broken (bad ARN, unknown profile) | Surface loudly, never retry           | `2`   |
+| Transient (STS throttle, network)           | Back off and retry                    | `2`   |
+| A human must act (SSO expired, MFA)         | Enter an attention flow, do not retry | `2`   |
+
+Retrying a malformed ARN forever generates noise that buries the real message.
+Not retrying a throttle turns a blip into an outage. Retrying an expired SSO
+session spawns a browser tab per attempt.
+
+**Proposed additions**, leaving `0` and `1` untouched:
+
+- `2` — error. Permanent for this request as posed. Do not retry.
+- `3` — retry. Transient; back off and retry within budget.
+- `4` — needs attention. A human must act; do not retry blindly.
+
+`3` and `4` want structured detail (a retry-after hint; a remediation command, an
+auth scope, a device code), which is another argument for the envelope in §2.
+
+Adding codes to a protocol with one implementation is nearly free. Doing it once
+third-party handlers exist is a breaking change. This is worth doing now even if
+§2 is deferred.
+
+## 4. Interactive re-auth cannot block the request
+
+`handler-aws.md` specifies that `autoSsoLogin` spawns `aws sso login` and "blocks
+until the user approves in the browser", with a note to raise the handler timeout
+to 120000ms.
+
+This addresses the wrong side of the transaction. AWS SDKs give IMDS roughly one
+second with a small retry budget; several mark the endpoint unavailable for the
+remaining process lifetime after repeated failure. A 120-second handler timeout
+does not buy patience — the SDK gave up 119 seconds earlier, and a long-running
+container may now refuse to try IMDS again until it restarts. The developer
+experiences a hang followed by a failure, which is strictly less informative than
+an immediate clean "no role" response plus a desktop notification.
+
+Two changes follow:
+
+**Fail fast, remediate out of band.** The handler returns "needs attention" with
+the command to run. The server holds the request only briefly — short enough to
+stay inside the SDK's read timeout, so a fast remediation can still be served
+inline — then answers. Remediation runs in the background; the SDK's own retry
+picks up the result once the cache is warm.
+
+**Deduplicate logins on auth scope, not on identity.** One SSO login unblocks
+every role in that SSO instance. Ten containers spanning six roles must produce
+exactly one browser tab. Keying deduplication on the resolved identity produces
+six. Only the handler knows the scope, and only the server sees the concurrency,
+so the scope has to cross the protocol boundary as a field.
+
+Under the current subprocess model with `autoSsoLogin` as specified, twelve
+containers starting together spawn twelve `aws sso login` processes. Nothing in
+the protocol prevents it today.
+
+## 5. Session naming and cache keys interact
+
+A concrete trap, worth recording because it is easy to walk into twice.
+
+`handler-aws.md` sets the default session name to
+`imds-server-{container-name}` — per container. It keys the cache on role ARN +
+profile + caller identity — per role. Both cannot hold:
+
+- If the session name is part of the cache key, twelve replicas of one service
+  produce twelve `AssumeRole` calls and the cache does nothing for the burst case
+  it exists to solve.
+- If it is not, cached credentials get served to containers under a session name
+  minted for a different container, and CloudTrail attribution is quietly wrong.
+
+Pick one, explicitly:
+
+- **Per-binding session names** (`imds-server-{role}` or similar) preserve
+  coalescing and make CloudTrail honest at the granularity of "this laptop, this
+  role". On a single-developer machine, the containers being collapsed are the
+  same human doing the same work.
+- **Per-container session names** keep finer attribution and accept one STS call
+  per container.
+
+The default should be per-binding, with per-container available as a
+configuration option and the cache cost documented at the config site. Whichever
+we choose, the choice determines the cache key, so it should be settled before
+the cache is implemented.
+
+## What this note does not decide
+
+- Whether to adopt the envelope (§2a) or sniff (§2b) — a real fork.
+- Whether the server should pre-warm credentials at container start rather than
+  waiting for the first request. Container boot time is the only window in the
+  system wide enough to hold a human, which makes it attractive for the SSO case,
+  but it spends STS quota on containers that may never make an AWS call.
+- Request delivery. `handler-commands.md` already anticipates stdin for larger
+  payloads; if the envelope lands, symmetric JSON-in/JSON-out is worth
+  considering over the current flags.
+- A conformance harness. If a three-line bash script is a supported extension
+  point, an `imds-server verify-handler ./my-handler` command is what keeps that
+  promise honest — a prose contract is one every implementer misreads
+  differently.
+
+## Compatibility
+
+§3 (status codes) is additive and safe to land immediately: existing handlers
+returning `0`, `1`, or `2` keep working unchanged.
+
+§1 (cache location) touches no protocol surface — it removes planned handler
+functionality and adds server functionality.
+
+§2 (envelope) is breaking and should be versioned. Since `@imdsutil/imds-handler-aws`
+is the only handler in existence and is not yet published, the window for making
+it cheaply is now.

--- a/docs/design/handler-state-ownership.md
+++ b/docs/design/handler-state-ownership.md
@@ -122,6 +122,8 @@ it is the decision in this note I hold most loosely. (b) is a legitimate
 near-term compromise if we want caching before we want a stable third-party
 contract.
 
+_Amended by §6: (b) turns out not to be viable for the failure paths at all._
+
 ## 3. The status vocabulary is too narrow
 
 Current contract:
@@ -222,9 +224,43 @@ configuration option and the cache cost documented at the config site. Whichever
 we choose, the choice determines the cache key, so it should be settled before
 the cache is implemented.
 
+## 6. Implementing §3 showed that sniffing cannot carry the detail
+
+§3 has since landed. Doing it surfaced an argument against option (b) that this
+note did not have when it was written, and it is the strongest one available.
+
+Option (b) reads the expiry out of the response body. Exit codes `3` and `4`
+have no response body. A handler that is being throttled, or that needs an SSO
+login, produced no credentials to render — that is the entire point of the
+status. There is nothing on stdout to sniff.
+
+So the two paths do not merely differ in cleanliness. Sniffing works on the
+success path only, and every piece of structured detail this note asks for on
+the failure paths — the retry-after hint in §3, the remediation command and the
+auth scope in §4 — has no channel under (b) at all.
+
+The implementation made the gap concrete by working around it. Needs-attention
+currently logs the handler's stderr as the remediation string, because stderr is
+the only thing crossing the boundary on a failure. That is serviceable for a
+human reading logs and useless for anything else: it is untyped free text, and
+§4's deduplication has to key on the auth scope. Keying dedup on a substring of
+stderr is not a design anyone would defend.
+
+This does not resolve the fork by itself — (c), the sidecar, still carries
+failure-path metadata, and it was set aside for fiddliness rather than
+incapacity. But it does remove (b) from contention for anything beyond a
+success-path cache. If the SSO story in §4 is wanted, the choice is (a) or (c),
+and (a) is the one that also solves multi-cloud rendering.
+
+**Revised recommendation:** (a), now held considerably less loosely. (b) remains
+viable only if the scope is narrowed to caching successful credential responses
+and §4 is abandoned or deferred indefinitely.
+
 ## What this note does not decide
 
-- Whether to adopt the envelope (§2a) or sniff (§2b) — a real fork.
+- Whether to adopt the envelope (§2a) or the sidecar (§2c). §6 narrows the fork
+  by ruling out sniffing (§2b) for anything but a success-path cache, but does
+  not settle the remaining two.
 - Whether the server should pre-warm credentials at container start rather than
   waiting for the first request. Container boot time is the only window in the
   system wide enough to hold a human, which makes it attractive for the SSO case,
@@ -240,7 +276,7 @@ the cache is implemented.
 ## Compatibility
 
 §3 (status codes) is additive and safe to land immediately: existing handlers
-returning `0`, `1`, or `2` keep working unchanged.
+returning `0`, `1`, or `2` keep working unchanged. This has landed.
 
 §1 (cache location) touches no protocol surface — it removes planned handler
 functionality and adds server functionality.

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -3,11 +3,15 @@
 // Handlers are defined separately in their own modules and composed here.
 
 import { notFoundHandler } from "./not-found.js";
+import { statusHandler } from "./status.js";
 import { tokenHandler } from "./token.js";
 
 // Handler registry—populated when concrete handlers are implemented.
 // Format: { method, path, handler }
 // Paths are matched with longest-prefix-wins semantics.
-export const HANDLERS = [{ method: "PUT", path: "/latest/api/token", handler: tokenHandler }];
+export const HANDLERS = [
+  { method: "GET", path: "/status", handler: statusHandler },
+  { method: "PUT", path: "/latest/api/token", handler: tokenHandler },
+];
 
 export { notFoundHandler };

--- a/src/handlers/status.js
+++ b/src/handlers/status.js
@@ -1,0 +1,7 @@
+// Status endpoint: confirms the server is running.
+// Not part of any IMDS spec — used for health checks and e2e test verification.
+
+export async function statusHandler(_req, res) {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("ok\n");
+}

--- a/src/index.js
+++ b/src/index.js
@@ -79,12 +79,14 @@ if (cliValues.help) {
   const router = new Router(allHandlers);
 
   const routingHandler = async (req, res) => {
-    // Validate token requirement based on IMDS version mode
-    const tokenError = validateTokenRequirement(req, config, tokenStore);
-    if (tokenError) {
-      res.writeHead(tokenError, { "Content-Type": "text/plain" });
-      res.end(tokenError === 401 ? "Unauthorized\n" : "Forbidden\n");
-      return;
+    // Token validation only applies to IMDS paths — non-IMDS paths (e.g. /status) are exempt
+    if (req.url.startsWith("/latest")) {
+      const tokenError = validateTokenRequirement(req, config, tokenStore);
+      if (tokenError) {
+        res.writeHead(tokenError, { "Content-Type": "text/plain" });
+        res.end(tokenError === 401 ? "Unauthorized\n" : "Forbidden\n");
+        return;
+      }
     }
 
     const match = router.match(req.method, req.url);

--- a/test/integration/status.test.js
+++ b/test/integration/status.test.js
@@ -1,0 +1,141 @@
+import { describe, it, afterEach } from "node:test";
+import { request } from "node:http";
+import assert from "node:assert/strict";
+import { createImdsServer } from "../../src/server/create-server.js";
+import { withMiddleware, validateTokenRequirement } from "../../src/server/middleware.js";
+import { createLogger } from "../../src/util/logger.js";
+import { Router } from "../../src/server/router.js";
+import { HANDLERS, notFoundHandler } from "../../src/handlers/index.js";
+import { TokenStore } from "../../src/session/token-store.js";
+
+const logger = createLogger("error");
+
+function createTestServer(config) {
+  const tokenStore = new TokenStore();
+  const router = new Router(HANDLERS);
+
+  const routingHandler = async (req, res) => {
+    if (req.url.startsWith("/latest")) {
+      const tokenError = validateTokenRequirement(req, config, tokenStore);
+      if (tokenError) {
+        res.writeHead(tokenError, { "Content-Type": "text/plain" });
+        res.end(tokenError === 401 ? "Unauthorized\n" : "Forbidden\n");
+        return;
+      }
+    }
+
+    const match = router.match(req.method, req.url);
+
+    if (!match) {
+      await notFoundHandler(req, res, { logger, config, tokenStore });
+      return;
+    }
+
+    if (match.status === 405) {
+      res.writeHead(405, { Allow: match.allowed.join(", "), "Content-Type": "text/plain" });
+      res.end("Method Not Allowed\n");
+      return;
+    }
+
+    await match.handler(req, res, {
+      logger,
+      config,
+      tokenStore,
+      pathRemainder: match.pathRemainder,
+    });
+  };
+
+  const handler = withMiddleware(routingHandler, logger);
+  const { start, close, server } = createImdsServer(config, handler, logger);
+  return { start, close, server };
+}
+
+function httpGet(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: "127.0.0.1", port, path, method: "GET" }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => resolve({ status: res.statusCode, body }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("status endpoint", () => {
+  let closeFn;
+
+  afterEach(async () => {
+    if (closeFn) {
+      await closeFn();
+      closeFn = null;
+    }
+  });
+
+  it("GET /status returns 200", async () => {
+    const config = {
+      port: 0,
+      host: "127.0.0.1",
+      socket: null,
+      imdsVersion: "2",
+      tokenRequired: true,
+    };
+    const { start, close, server } = createTestServer(config);
+    closeFn = close;
+
+    await start();
+    const port = server.address().port;
+
+    const res = await httpGet(port, "/status");
+    assert.equal(res.status, 200);
+    assert.equal(res.body, "ok\n");
+  });
+
+  it("GET /status does not require an IMDSv2 token", async () => {
+    const config = {
+      port: 0,
+      host: "127.0.0.1",
+      socket: null,
+      imdsVersion: "2",
+      tokenRequired: true,
+    };
+    const { start, close, server } = createTestServer(config);
+    closeFn = close;
+
+    await start();
+    const port = server.address().port;
+
+    // No X-Aws-Ec2-Metadata-Token header — should still succeed
+    const res = await httpGet(port, "/status");
+    assert.equal(res.status, 200);
+  });
+
+  it("POST /status returns 405", async () => {
+    const config = {
+      port: 0,
+      host: "127.0.0.1",
+      socket: null,
+      imdsVersion: "2",
+      tokenRequired: true,
+    };
+    const { start, close, server } = createTestServer(config);
+    closeFn = close;
+
+    await start();
+    const port = server.address().port;
+
+    const res = await new Promise((resolve, reject) => {
+      const req = request(
+        { hostname: "127.0.0.1", port, path: "/status", method: "POST" },
+        (res) => {
+          let body = "";
+          res.on("data", (chunk) => (body += chunk));
+          res.on("end", () => resolve({ status: res.statusCode, body }));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    assert.equal(res.status, 405);
+  });
+});


### PR DESCRIPTION
Four commits of design work, none of which had been committed anywhere. Two threads that happen to be stacked.

## Label namespacing

`handler-commands.md` described a single cross-cloud `imds.role` label, but the AWS handler design and its implementation both use `imds.aws.role`. Namespacing per provider (`imds.<provider>.role`) also lets a container opt in to several handlers without the label colliding.

Also adds `handler-aws.md` itself, which had been the working reference for the `imds.aws.*` convention and the credential resolution order while existing only in a working tree. `cb8802d` aligned the tracked doc to a file that wasn't in the repo.

## Handler state ownership

`handler-commands.md` promises a working handler can be a three-line bash script, while `handler-aws.md` puts a credential cache inside the handler. Both cannot hold: a per-request process sees one request, never the request *stream*, so it cannot deduplicate against its own siblings or implement TTL and refresh correctly. Twelve containers starting together spawn twelve handler processes and twelve `AssumeRole` calls, and nothing in that picture can collapse them.

The note argues the conflict resolves in favour of the protocol — a handler is a pure function from container context to credentials, and every stateful concern belongs to the server — then works through the consequences: the cache moves server-side, the server must be able to read credential expiry, the status vocabulary needs widening, interactive re-auth cannot block the request, and session naming has to be settled before the cache key is.

**Status: proposal.** Merging it doesn't adopt it. The one part that has landed is the status vocabulary (#53).

## The open fork

The note originally left open whether the server learns credential expiry via a response envelope (§2a), content sniffing (§2b), or a sidecar channel (§2c).

Implementing #53 ruled out sniffing, which §6 records. Sniffing reads the response body — and exit `3` and exit `4` have no response body, since a throttled handler or one needing an SSO login produced no credentials to render. Every piece of failure-path detail the note wants (retry-after, remediation command, auth scope) therefore has no channel under (b) at all. #53 had to route remediation through stderr for want of anywhere else to put it, which serves a human reading logs and cannot support keying deduplication on auth scope.

That narrows the fork to the envelope or the sidecar, and revises the recommendation for the envelope from loosely to firmly held.

## Still undecided

Session naming (§5, per-binding vs per-container) determines the cache key, so it wants settling before any cache work starts. Not blocking this merge.