### PR TITLE
feat: parse the handler response envelope

### DIFF
--- a/docs/design/handler-commands.md
+++ b/docs/design/handler-commands.md
@@ -66,6 +66,12 @@ The server sets content-type based on the request type (e.g. `application/json`
 for credentials, `text/plain` for simple values). Handlers don't need to worry
 about headers or HTTP semantics.
 
+A handler that needs to tell the server something _about_ its response — when
+credentials expire, how long to wait before a retry, what a person should run to
+fix an expired login — can wrap it in an envelope instead. The envelope is
+optional and detected by an `imdsEnvelopeVersion` field; a bare body behaves
+exactly as described above. See `handler-envelope.md`.
+
 ### Exit Codes
 
 - `0` - handled. stdout is the response body.

--- a/src/handler/chain.js
+++ b/src/handler/chain.js
@@ -41,7 +41,7 @@ export class HandlerChain {
       });
 
       if (TERMINAL.has(result.status)) {
-        return result;
+        return { ...result, command: entry.command };
       }
     }
 

--- a/src/handler/envelope.js
+++ b/src/handler/envelope.js
@@ -1,0 +1,63 @@
+// Handler response envelope: detection and validation.
+//
+// A handler may write a bare response body, or an envelope carrying facts about
+// that body the server needs but cannot infer — expiry, a cache key, why a
+// failure happened. See docs/design/handler-envelope.md.
+//
+// Detection is deliberately narrow: an envelope is a JSON object with an
+// integer `imdsEnvelopeVersion`. Everything else is a body, relayed untouched.
+
+const MARKER = "imdsEnvelopeVersion";
+const SUPPORTED_VERSION = 1;
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Classify a handler's stdout as an envelope or a bare response body.
+ *
+ * @param {string} stdout - Raw handler output
+ * @param {string} status - Executor status the exit code produced
+ * @returns {{kind: "body", body: string}
+ *   | {kind: "envelope", envelope: object}
+ *   | {kind: "invalid", reason: string}}
+ */
+export function parseHandlerOutput(stdout, status) {
+  // Leading whitespace must go before the `{` test. A handler that pretty-prints
+  // its envelope would otherwise look like a body and have its control data
+  // relayed to the client — and since a body is a legitimate outcome, silently.
+  const trimmed = stdout.trimStart();
+
+  if (!trimmed.startsWith("{")) {
+    return { kind: "body", body: stdout };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // A handler emitting malformed JSON as its body is the handler's bug to
+    // surface, not ours to intercept. Relay it and let the client complain.
+    return { kind: "body", body: stdout };
+  }
+
+  if (!isPlainObject(parsed) || !Number.isInteger(parsed[MARKER])) {
+    return { kind: "body", body: stdout };
+  }
+
+  // Past this point the handler has claimed to speak the protocol, so problems
+  // are errors rather than grounds to fall back to relaying the raw bytes.
+  if (parsed[MARKER] !== SUPPORTED_VERSION) {
+    return {
+      kind: "invalid",
+      reason: `unsupported envelope version ${parsed[MARKER]}, expected ${SUPPORTED_VERSION}`,
+    };
+  }
+
+  if (status === "handled" && parsed.body === undefined) {
+    return { kind: "invalid", reason: "envelope on a handled response has no body" };
+  }
+
+  return { kind: "envelope", envelope: parsed };
+}

--- a/src/handlers/metadata.js
+++ b/src/handlers/metadata.js
@@ -2,8 +2,22 @@
 // and delegates to the handler chain for response generation.
 
 import { mapPathToRequestType } from "../handler/path-mapper.js";
+import { parseHandlerOutput } from "../handler/envelope.js";
+
+// Request types where an envelope buys the server something. Without one, a
+// credentials response cannot be cached or rendered for more than one endpoint,
+// which is worth telling the operator about once.
+const ENVELOPE_RECOMMENDED = new Set(["credentials"]);
+
+function renderBody(body) {
+  return typeof body === "string" ? body : JSON.stringify(body);
+}
 
 export function createMetadataHandler(chain, logger) {
+  // The same handler answers every request of a type for the life of the
+  // process, so the recommendation is logged once rather than on every call.
+  const recommended = new Set();
+
   return async (req, res) => {
     const requestType = mapPathToRequestType(req.url);
 
@@ -21,10 +35,37 @@ export function createMetadataHandler(chain, logger) {
     };
 
     const result = await chain.execute(requestType, request);
+    const parsed = parseHandlerOutput(result.stdout, result.status);
+
+    if (parsed.kind === "invalid") {
+      // The handler claimed to speak the protocol and got it wrong. Relaying the
+      // raw bytes would hand the client control data dressed as a response.
+      logger.error("handler returned an invalid envelope", {
+        requestType,
+        command: result.command,
+        reason: parsed.reason,
+      });
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Internal Server Error\n");
+      return;
+    }
+
+    const envelope = parsed.kind === "envelope" ? parsed.envelope : null;
 
     if (result.status === "handled") {
+      if (!envelope && ENVELOPE_RECOMMENDED.has(requestType)) {
+        const key = `${result.command}\u0000${requestType}`;
+        if (!recommended.has(key)) {
+          recommended.add(key);
+          logger.warn("handler response is not an envelope", {
+            requestType,
+            command: result.command,
+            detail: "responses for this type cannot be cached or re-rendered without one",
+          });
+        }
+      }
       res.writeHead(200, { "Content-Type": "text/plain" });
-      res.end(result.stdout);
+      res.end(envelope ? renderBody(envelope.body) : result.stdout);
     } else if (result.status === "error") {
       res.writeHead(500, { "Content-Type": "text/plain" });
       res.end("Internal Server Error\n");
@@ -32,16 +73,24 @@ export function createMetadataHandler(chain, logger) {
       // Transient. 503 is the one status AWS SDKs already back off and retry on,
       // so the handler's "try me again" reaches the client through the protocol
       // rather than through a convention the client would have to know about.
-      res.writeHead(503, { "Content-Type": "text/plain" });
+      const headers = { "Content-Type": "text/plain" };
+      if (Number.isFinite(envelope?.retryAfter)) {
+        headers["Retry-After"] = String(envelope.retryAfter);
+      }
+      res.writeHead(503, headers);
       res.end("Service Unavailable\n");
     } else if (result.status === "needs-attention") {
       // A person has to act, and no amount of waiting on this request will
       // summon them. Answering 404 makes this look like an instance with no
       // role attached, which the SDK credential chain handles cleanly instead
       // of hanging; the operator learns what to do from the log, not the wire.
+      // An envelope states the remediation; stderr is what a handler that
+      // hasn't adopted one has to offer, so fall back to it.
       logger.warn("handler needs attention", {
         requestType,
-        detail: result.stderr.trim(),
+        command: result.command,
+        detail: envelope?.remediation ?? result.stderr.trim(),
+        ...(envelope?.authScope ? { authScope: envelope.authScope } : {}),
       });
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found\n");

--- a/test/unit/handler/chain.test.js
+++ b/test/unit/handler/chain.test.js
@@ -217,3 +217,17 @@ test("HandlerChain: stops the chain on needs-attention", async () => {
   assert.equal(result.status, "needs-attention");
   assert.equal(calls.length, 1);
 });
+
+test("HandlerChain: reports which command produced the result", async () => {
+  const { executor } = stubExecutor({
+    "/usr/bin/handler-a": { status: "pass", stdout: "", stderr: "", timedOut: false },
+    "/usr/bin/handler-b": { status: "handled", stdout: "ok", stderr: "", timedOut: false },
+  });
+  const chain = new HandlerChain({ timeout: 5000, executor });
+  chain.register("credentials", "/usr/bin/handler-a");
+  chain.register("credentials", "/usr/bin/handler-b");
+
+  const result = await chain.execute("credentials", baseRequest);
+
+  assert.equal(result.command, "/usr/bin/handler-b");
+});

--- a/test/unit/handler/envelope.test.js
+++ b/test/unit/handler/envelope.test.js
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseHandlerOutput } from "../../../src/handler/envelope.js";
+
+describe("envelope detection", () => {
+  it("treats a plain string as a bare body", () => {
+    const result = parseHandlerOutput("i-1234567890abcdef0\n", "handled");
+
+    assert.equal(result.kind, "body");
+    assert.equal(result.body, "i-1234567890abcdef0\n");
+  });
+
+  it("treats JSON without the marker as a bare body", () => {
+    const raw = '{"Code":"Success","AccessKeyId":"ASIA"}';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "body");
+    assert.equal(result.body, raw);
+  });
+
+  it("does not mistake the instance identity document for an envelope", () => {
+    const raw = '{"accountId":"111122223333","version":"2017-09-30"}';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "body");
+  });
+
+  it("detects an envelope by its marker", () => {
+    const raw = '{"imdsEnvelopeVersion":1,"body":"i-123"}';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "envelope");
+    assert.equal(result.envelope.body, "i-123");
+  });
+
+  it("strips leading whitespace before testing", () => {
+    const raw = '\n  {\n  "imdsEnvelopeVersion": 1,\n  "body": "i-123"\n}';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "envelope");
+    assert.equal(result.envelope.body, "i-123");
+  });
+
+  it("treats a non-integer marker as a bare body", () => {
+    const raw = '{"imdsEnvelopeVersion":"1","body":"x"}';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "body");
+  });
+
+  it("treats unparseable JSON as a bare body", () => {
+    const raw = '{"Code":"Success",';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "body");
+    assert.equal(result.body, raw);
+  });
+
+  it("treats a JSON array as a bare body", () => {
+    const result = parseHandlerOutput('["a","b"]', "handled");
+
+    assert.equal(result.kind, "body");
+  });
+});
+
+describe("envelope validation: the marker binds", () => {
+  it("rejects an unsupported version rather than proxying it", () => {
+    const result = parseHandlerOutput('{"imdsEnvelopeVersion":99,"body":"x"}', "handled");
+
+    assert.equal(result.kind, "invalid");
+    assert.match(result.reason, /version/i);
+  });
+
+  it("rejects a handled envelope with no body", () => {
+    const result = parseHandlerOutput('{"imdsEnvelopeVersion":1}', "handled");
+
+    assert.equal(result.kind, "invalid");
+    assert.match(result.reason, /body/i);
+  });
+
+  it("allows a failure envelope with no body", () => {
+    const result = parseHandlerOutput('{"imdsEnvelopeVersion":1,"retryAfter":30}', "retry");
+
+    assert.equal(result.kind, "envelope");
+    assert.equal(result.envelope.retryAfter, 30);
+  });
+
+  it("carries remediation and authScope on needs-attention", () => {
+    const raw = JSON.stringify({
+      imdsEnvelopeVersion: 1,
+      remediation: "aws sso login",
+      authScope: "sso:acme.awsapps.com/start",
+    });
+    const result = parseHandlerOutput(raw, "needs-attention");
+
+    assert.equal(result.kind, "envelope");
+    assert.equal(result.envelope.remediation, "aws sso login");
+    assert.equal(result.envelope.authScope, "sso:acme.awsapps.com/start");
+  });
+
+  it("ignores unknown fields so later versions can add them", () => {
+    const raw = '{"imdsEnvelopeVersion":1,"body":"x","somethingNew":true}';
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.kind, "envelope");
+    assert.equal(result.envelope.body, "x");
+  });
+
+  it("carries expiresAt and cacheKey through for the cache to use", () => {
+    const raw = JSON.stringify({
+      imdsEnvelopeVersion: 1,
+      body: "x",
+      expiresAt: "2026-08-27T18:00:00Z",
+      cacheKey: "aws:role/dev",
+    });
+    const result = parseHandlerOutput(raw, "handled");
+
+    assert.equal(result.envelope.expiresAt, "2026-08-27T18:00:00Z");
+    assert.equal(result.envelope.cacheKey, "aws:role/dev");
+  });
+});

--- a/test/unit/handlers/metadata.test.js
+++ b/test/unit/handlers/metadata.test.js
@@ -43,7 +43,7 @@ function mockRes() {
 describe("metadata handler", () => {
   it("returns handler stdout on handled status", async () => {
     const chain = stubChain({ status: "handled", stdout: '{"key":"val"}', stderr: "" });
-    const handler = createMetadataHandler(chain);
+    const handler = createMetadataHandler(chain, stubLogger());
     const req = mockReq("/latest/meta-data/iam/security-credentials/my-role");
     const res = mockRes();
 
@@ -56,7 +56,7 @@ describe("metadata handler", () => {
 
   it("returns 404 when no handler matches", async () => {
     const chain = stubChain({ status: "no-handler", stdout: "", stderr: "" });
-    const handler = createMetadataHandler(chain);
+    const handler = createMetadataHandler(chain, stubLogger());
     const req = mockReq("/latest/meta-data/instance-id");
     const res = mockRes();
 
@@ -67,7 +67,7 @@ describe("metadata handler", () => {
 
   it("returns 500 on handler error", async () => {
     const chain = stubChain({ status: "error", stdout: "", stderr: "boom" });
-    const handler = createMetadataHandler(chain);
+    const handler = createMetadataHandler(chain, stubLogger());
     const req = mockReq("/latest/meta-data/instance-id");
     const res = mockRes();
 
@@ -78,7 +78,7 @@ describe("metadata handler", () => {
 
   it("returns 404 for unmapped path", async () => {
     const chain = stubChain({ status: "handled", stdout: "nope", stderr: "" });
-    const handler = createMetadataHandler(chain);
+    const handler = createMetadataHandler(chain, stubLogger());
     const req = mockReq("/latest/meta-data/something-unknown");
     const res = mockRes();
 
@@ -90,7 +90,7 @@ describe("metadata handler", () => {
 
   it("passes container info to the chain", async () => {
     const chain = stubChain({ status: "handled", stdout: "ok", stderr: "" });
-    const handler = createMetadataHandler(chain);
+    const handler = createMetadataHandler(chain, stubLogger());
     const req = mockReq("/latest/meta-data/iam/security-credentials/role", {
       id: "container-1",
       name: "web-app",
@@ -108,7 +108,7 @@ describe("metadata handler", () => {
 
   it("passes the full request path to the chain", async () => {
     const chain = stubChain({ status: "handled", stdout: "ok", stderr: "" });
-    const handler = createMetadataHandler(chain);
+    const handler = createMetadataHandler(chain, stubLogger());
     const req = mockReq("/latest/meta-data/iam/security-credentials/my-role");
     const res = mockRes();
 
@@ -174,5 +174,148 @@ describe("metadata handler status vocabulary", () => {
     assert.ok(warned, "expected a warn entry");
     assert.equal(warned.detail, "run: aws sso login");
     assert.equal(warned.requestType, "credentials");
+  });
+});
+
+describe("metadata handler envelope support", () => {
+  it("sends a bare body through untouched", async () => {
+    const chain = stubChain({ status: "handled", stdout: "i-123", stderr: "" });
+    const handler = createMetadataHandler(chain, stubLogger());
+    const res = mockRes();
+
+    await handler(mockReq("/latest/meta-data/instance-id"), res, {});
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body, "i-123");
+  });
+
+  it("unwraps an envelope and sends only the body", async () => {
+    const chain = stubChain({
+      status: "handled",
+      stdout: '{"imdsEnvelopeVersion":1,"body":"i-123"}',
+      stderr: "",
+    });
+    const handler = createMetadataHandler(chain, stubLogger());
+    const res = mockRes();
+
+    await handler(mockReq("/latest/meta-data/instance-id"), res, {});
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body, "i-123");
+  });
+
+  it("serialises an object body", async () => {
+    const chain = stubChain({
+      status: "handled",
+      stdout: '{"imdsEnvelopeVersion":1,"body":{"accessKeyId":"ASIA"}}',
+      stderr: "",
+    });
+    const handler = createMetadataHandler(chain, stubLogger());
+    const res = mockRes();
+
+    await handler(mockReq("/latest/meta-data/iam/security-credentials/dev"), res, {});
+
+    assert.equal(res.body, '{"accessKeyId":"ASIA"}');
+  });
+
+  it("returns 500 for an invalid envelope rather than proxying it", async () => {
+    const logger = stubLogger();
+    const chain = stubChain({
+      status: "handled",
+      stdout: '{"imdsEnvelopeVersion":99,"body":"x"}',
+      stderr: "",
+    });
+    const handler = createMetadataHandler(chain, logger);
+    const res = mockRes();
+
+    await handler(mockReq("/latest/meta-data/instance-id"), res, {});
+
+    assert.equal(res.statusCode, 500);
+    assert.notEqual(res.body, "x");
+    assert.ok(logger.entries.find((e) => e.level === "error"));
+  });
+
+  it("sets Retry-After from the envelope on retry", async () => {
+    const chain = stubChain({
+      status: "retry",
+      stdout: '{"imdsEnvelopeVersion":1,"retryAfter":30}',
+      stderr: "",
+    });
+    const handler = createMetadataHandler(chain, stubLogger());
+    const res = mockRes();
+
+    await handler(mockReq("/latest/meta-data/instance-id"), res, {});
+
+    assert.equal(res.statusCode, 503);
+    assert.equal(res.headers["Retry-After"], "30");
+  });
+
+  it("prefers envelope remediation over stderr on needs-attention", async () => {
+    const logger = stubLogger();
+    const chain = stubChain({
+      status: "needs-attention",
+      stdout: '{"imdsEnvelopeVersion":1,"remediation":"aws sso login","authScope":"sso:acme"}',
+      stderr: "some noisy stderr",
+    });
+    const handler = createMetadataHandler(chain, logger);
+    const res = mockRes();
+
+    await handler(mockReq("/latest/meta-data/instance-id"), res, {});
+
+    const warned = logger.entries.find((e) => e.level === "warn");
+    assert.equal(warned.detail, "aws sso login");
+    assert.equal(warned.authScope, "sso:acme");
+  });
+});
+
+describe("metadata handler envelope recommendation", () => {
+  it("warns when a credentials handler returns no envelope", async () => {
+    const logger = stubLogger();
+    const chain = stubChain({
+      status: "handled",
+      stdout: '{"Code":"Success"}',
+      stderr: "",
+      command: "/opt/handlers/aws",
+    });
+    const handler = createMetadataHandler(chain, logger);
+
+    await handler(mockReq("/latest/meta-data/iam/security-credentials/dev"), mockRes(), {});
+
+    const warned = logger.entries.find((e) => e.level === "warn");
+    assert.ok(warned, "expected a warning");
+    assert.equal(warned.command, "/opt/handlers/aws");
+  });
+
+  it("warns only once per handler and request type", async () => {
+    const logger = stubLogger();
+    const chain = stubChain({
+      status: "handled",
+      stdout: '{"Code":"Success"}',
+      stderr: "",
+      command: "/opt/handlers/aws",
+    });
+    const handler = createMetadataHandler(chain, logger);
+    const req = () => mockReq("/latest/meta-data/iam/security-credentials/dev");
+
+    await handler(req(), mockRes(), {});
+    await handler(req(), mockRes(), {});
+    await handler(req(), mockRes(), {});
+
+    assert.equal(logger.entries.filter((e) => e.level === "warn").length, 1);
+  });
+
+  it("does not warn for types that gain nothing from an envelope", async () => {
+    const logger = stubLogger();
+    const chain = stubChain({
+      status: "handled",
+      stdout: "i-123",
+      stderr: "",
+      command: "/opt/handlers/simple",
+    });
+    const handler = createMetadataHandler(chain, logger);
+
+    await handler(mockReq("/latest/meta-data/instance-id"), mockRes(), {});
+
+    assert.equal(logger.entries.filter((e) => e.level === "warn").length, 0);
   });
 });


### PR DESCRIPTION
Implements `docs/design/handler-envelope.md` (#57). A handler may now wrap its response in an envelope carrying facts the server needs but cannot infer. A handler that writes a bare body is unaffected.

## Detection

`src/handler/envelope.js` — strip leading whitespace, require a leading `{`, parse, require an integer `imdsEnvelopeVersion`. Anything failing that is a body and is relayed untouched.

That includes **malformed JSON**: a handler emitting bad JSON as its body is its own bug to surface, not ours to intercept. Relay it and let the client complain.

The whitespace strip is load-bearing rather than cosmetic — a pretty-printed envelope would otherwise fail detection and have its control data relayed to the client as the response, silently, because a bare body is a legitimate outcome.

## Once the marker is present, it binds

An unsupported version, or a `handled` response with no `body`, returns **500** and logs — never a fallback to relaying the raw bytes. Falling back would hand the client control data dressed as a response, failing far from the cause.

## Envelope detail reaches the wire and the log

| Field | Effect |
| --- | --- |
| `body` | Sent as the response; objects serialised, strings verbatim |
| `retryAfter` | Becomes a `Retry-After` header on the 503 |
| `remediation` | Replaces stderr as the warn-log detail on needs-attention |
| `authScope` | Added to that log entry |

`remediation` falls back to stderr for handlers that haven't adopted an envelope, so #53's behaviour is preserved for them.

`expiresAt` and `cacheKey` are parsed and carried but have no consumer yet — they land with the cache (§1 of the state-ownership note).

## The recommendation warning

A handler answering `credentials` without an envelope gets **one** warning per handler and request type, naming what it gives up. Not per request: the same handler answers every credential fetch for the life of the process, so per-request would print the same line thousands of times and train the operator to ignore it.

`HandlerChain` now reports which command produced a result, so the warning can name it.

## Tests

241 passing (24 new), lint clean.

Covers the collision cases from the spec's audit: a credentials body, the instance identity document (which carries `"version"`), a JSON array, a non-integer marker, unparseable JSON, and a pretty-printed envelope with leading whitespace.

Six pre-existing tests in `metadata.test.js` now pass a stub logger — the warning path made the logger genuinely required rather than optional.

## Not included

The cache, ECS-shape rendering, and the per-type detection opt-out for arbitrary bodies (`/latest/user-data` isn't a mapped request type yet). Each needs something that doesn't exist.