### PR TITLE
ci: skip the test matrix and security scans for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,26 +29,6 @@ jobs:
 
       - run: pnpm format:check
 
-  test:
-    name: Test (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22, 24]
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm test
-
   commitlint:
     name: Commit Messages
     if: github.event_name == 'pull_request'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,10 +1,20 @@
 name: Security
 
+# Docs-only changes are skipped: CodeQL has no source to analyse, dependency
+# review has no manifest to diff, and the container image is unaffected.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - LICENSE
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - LICENSE
   schedule:
     - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+# Split from ci.yml so the matrix can skip changes that cannot affect it.
+# Lint stays in ci.yml and runs unconditionally: format:check covers Markdown,
+# so docs changes still need it.
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - LICENSE
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - LICENSE
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test


### PR DESCRIPTION
`ci.yml` and `security.yml` both trigger on `pull_request` **and** `push` to main, so every change costs two full runs. Four of the last six PRs changed nothing but prose and still ran Node 20/22/24 plus CodeQL.

## What changed

| Workflow | Runs on docs-only? | Why |
| --- | --- | --- |
| `ci.yml` → `lint` | **yes** | Runs `format:check`, which covers Markdown |
| `ci.yml` → `commitlint` | **yes** | The commit message matters whatever changed |
| `test.yml` (new) | no | Nothing in `docs/**` can change a test result |
| `security.yml` | no | No source for CodeQL, no manifest to diff, image unaffected |

## Why the matrix moved to its own file

GitHub has no per-job `paths-ignore`, and a workflow-level ignore on `ci.yml` would have been wrong — it would take `lint` and `commitlint` with it. `format:check` is the only thing guarding Markdown formatting for docs edited outside a lint-staged commit, and prose is exactly what it exists to check.

Splitting the matrix into `test.yml` is the native way to scope the ignore. Job names are unchanged, so the checks still report as `Test (Node 20)` and so on.

## Notes

Anchors are expanded rather than shared via `&docs`/`*docs`. YAML aliases aren't dependably supported in workflow files, and a silent parse difference here isn't worth saving four lines.

`main` has no branch protection, so nothing hangs waiting on a skipped check. If protection is added later, these must not be marked required — a skipped required check blocks the merge forever.

This PR touches workflows, so it exercises the full set itself.